### PR TITLE
Include fields in equivalency assertions

### DIFF
--- a/FluentAssertions.Core/Collections/GenericCollectionAssertions.cs
+++ b/FluentAssertions.Core/Collections/GenericCollectionAssertions.cs
@@ -74,7 +74,7 @@ namespace FluentAssertions.Collections
                     .ForCondition(unordered.SequenceEqual(expectation))
                     .BecauseOf(because, args)
                     .FailWith("Expected collection {0} to be ordered by {1}{reason} and result in {2}.",
-                        Subject, propertyExpression.GetPropertyPath(), expectation);
+                        Subject, propertyExpression.GetMemberPath(), expectation);
             }
             
             return new AndConstraint<GenericCollectionAssertions<T>>(this);
@@ -92,7 +92,7 @@ namespace FluentAssertions.Collections
                 .ForCondition(!ReferenceEquals(Subject, null))
                 .BecauseOf(because, args)
                 .FailWith("Expected collection to be ordered by {0}{reason} but found <null>.",
-                    propertyExpression.GetPropertyPath());
+                    propertyExpression.GetMemberPath());
         }
 
         private enum SortDirection

--- a/FluentAssertions.Core/Common/ExpressionExtensions.cs
+++ b/FluentAssertions.Core/Common/ExpressionExtensions.cs
@@ -20,10 +20,19 @@ namespace FluentAssertions.Common
             MemberInfo memberInfo = AttemptToGetMemberInfoFromCastExpression(expression) ??
                                     AttemptToGetMemberInfoFromMemberExpression(expression);
 
-            var propertyInfo = memberInfo as PropertyInfo;
-            if (propertyInfo != null)
+            if (memberInfo != null)
             {
-                return SelectedMemberInfo.Create(propertyInfo);
+                var propertyInfo = memberInfo as PropertyInfo;
+                if (propertyInfo != null)
+                {
+                    return SelectedMemberInfo.Create(propertyInfo);
+                }
+
+                var fieldInfo = memberInfo as FieldInfo;
+                if (fieldInfo != null)
+                {
+                    return SelectedMemberInfo.Create(fieldInfo);
+                }
             }
 
             throw new ArgumentException(

--- a/FluentAssertions.Core/Common/ExpressionExtensions.cs
+++ b/FluentAssertions.Core/Common/ExpressionExtensions.cs
@@ -76,11 +76,11 @@ namespace FluentAssertions.Common
         /// <summary>
         /// Gets a dotted path of property names representing the property expression. E.g. Parent.Child.Sibling.Name.
         /// </summary>
-        public static string GetPropertyPath<TDeclaringType, TPropertyType>(
-            this Expression<Func<TDeclaringType, TPropertyType>> propertyExpression)
+        public static string GetMemberPath<TDeclaringType, TPropertyType>(
+            this Expression<Func<TDeclaringType, TPropertyType>> expression)
         {
             var segments = new List<string>();
-            Expression node = propertyExpression;
+            Expression node = expression;
 
             while (node != null)
             {
@@ -95,11 +95,11 @@ namespace FluentAssertions.Common
                         var unaryExpression = (UnaryExpression)node;
                         node = unaryExpression.Operand;
                         break;
-                    
+
                     case ExpressionType.MemberAccess:
                         var memberExpression = (MemberExpression)node;
                         node = memberExpression.Expression;
-                        
+
                         segments.Add(memberExpression.Member.Name);
                         break;
 
@@ -117,11 +117,18 @@ namespace FluentAssertions.Common
 
                     default:
                         throw new ArgumentException(
-                            string.Format("Expression <{0}> cannot be used to select a member.", propertyExpression.Body));
+                            string.Format("Expression <{0}> cannot be used to select a member.", expression.Body));
                 }
             }
 
             return string.Join(".", segments.AsEnumerable().Reverse().ToArray()).Replace(".[", "[");
+        }
+
+        [Obsolete("This method will be removed in a future version.  Use `GetMemberPath(expression)` instead.")]
+        public static string GetPropertyPath<TDeclaringType, TPropertyType>(
+            this Expression<Func<TDeclaringType, TPropertyType>> propertyExpression)
+        {
+            return GetMemberPath(propertyExpression);
         }
     }
 }

--- a/FluentAssertions.Core/Core.csproj
+++ b/FluentAssertions.Core/Core.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Common\NullReflector.cs" />
     <Compile Include="Common\PlatformAdapter.cs" />
     <Compile Include="Common\ProbingAdapterResolver.cs" />
+    <Compile Include="Equivalency\AllPublicFieldsSelectionRule.cs" />
     <Compile Include="Equivalency\AssertionContext.cs" />
     <Compile Include="Equivalency\AssertionRuleEquivalencyStep.cs" />
     <Compile Include="Equivalency\AssertionRuleEquivalencyStepAdaptor.cs" />

--- a/FluentAssertions.Core/Equivalency/AllPublicFieldsSelectionRule.cs
+++ b/FluentAssertions.Core/Equivalency/AllPublicFieldsSelectionRule.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using FluentAssertions.Common;
+
+namespace FluentAssertions.Equivalency
+{
+    /// <summary>
+    /// Selection rule that adds all public fields of the subject. 
+    /// </summary>
+    internal class AllPublicFieldsSelectionRule : IMemberSelectionRule
+    {
+        public IEnumerable<ISelectedMemberInfo> SelectMembers(IEnumerable<ISelectedMemberInfo> selectedMembers, ISubjectInfo context, IEquivalencyAssertionOptions config)
+        {
+            return
+                selectedMembers.Union(
+                    config.GetSubjectType(context).GetNonPrivateFields().Select(SelectedMemberInfo.Create));
+        }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>
+        /// A string that represents the current object.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
+        public override string ToString()
+        {
+            return "Include all non-private fields";
+        }
+    }
+}

--- a/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptions.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptions.cs
@@ -101,7 +101,7 @@ namespace FluentAssertions.Equivalency
         public EquivalencyAssertionOptions()
         {
             IncludingNestedObjects();
-            IncludingAllDeclaredProperties();
+            IncludingAllDeclaredMembers();
         }
     }
 }

--- a/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptions.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptions.cs
@@ -46,7 +46,7 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         public EquivalencyAssertionOptions<TSubject> Excluding(Expression<Func<TSubject, object>> expression)
         {
-            AddSelectionRule(new ExcludeMemberByPathSelectionRule(expression.GetPropertyPath()));
+            AddSelectionRule(new ExcludeMemberByPathSelectionRule(expression.GetMemberPath()));
             return this;
         }
 
@@ -88,7 +88,7 @@ namespace FluentAssertions.Equivalency
         public EquivalencyAssertionOptions<TSubject> WithStrictOrderingFor(
             Expression<Func<TSubject, object>> expression)
         {
-            orderingRules.Add(new PathBasedOrderingRule(expression.GetPropertyPath()));
+            orderingRules.Add(new PathBasedOrderingRule(expression.GetMemberPath()));
             return this;
         }
     }

--- a/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptionsBase.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptionsBase.cs
@@ -202,7 +202,7 @@ namespace FluentAssertions.Equivalency
         /// Tries to match the properties of the subject with equally named properties on the expectation. Ignores those 
         /// properties that don't exist on the expectation and previously registered matching rules.
         /// </summary>
-        [Obsolete]
+        [Obsolete("This method will be removed in a future version.  Use `ExcludingMissingMembers()` instead.")]
         public TSelf ExcludingMissingProperties()
         {
             return ExcludingMissingMembers();
@@ -222,7 +222,7 @@ namespace FluentAssertions.Equivalency
         /// Requires the expectation to have properties which are equally named to properties on the subject.
         /// </summary>
         /// <returns></returns>
-        [Obsolete]
+        [Obsolete("This method will be removed in a future version.  Use `ThrowOnMissingMembers()` instead.")]
         public TSelf ThrowingOnMissingProperties()
         {
             return ThrowingOnMissingMembers();
@@ -314,7 +314,7 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Adds a selection rule to the ones already added by default, and which is evaluated after all existing rules.
         /// </summary>
-        [Obsolete]
+        [Obsolete("This method will be removed in a future version.  Use `Using(IMemberSelectionRule)` instead.")]
         public TSelf Using(ISelectionRule selectionRule)
         {
             return AddSelectionRule(new ObsoleteSelectionRuleAdapter(selectionRule));
@@ -323,7 +323,7 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Adds a matching rule to the ones already added by default, and which is evaluated before all existing rules.
         /// </summary>
-        [Obsolete]
+        [Obsolete("This method will be removed in a future version.  Use `Using(IMemberMatchingRule)` instead.")]
         public TSelf Using(IMatchingRule matchingRule)
         {
             return AddMatchingRule(new ObsoleteMatchingRuleAdapter(matchingRule));

--- a/FluentAssertions.Core/Equivalency/FieldSelectedMemberInfo.cs
+++ b/FluentAssertions.Core/Equivalency/FieldSelectedMemberInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 
 namespace FluentAssertions.Equivalency
@@ -17,6 +18,11 @@ namespace FluentAssertions.Equivalency
 
         public override object GetValue(object obj, object[] index)
         {
+            if ((index != null) && index.Any())
+            {
+                throw new TargetParameterCountException("Parameter count mismatch.");
+            }
+
             return fieldInfo.GetValue(obj);
         }
 

--- a/FluentAssertions.Core/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/FluentAssertions.Core/Equivalency/IEquivalencyAssertionOptions.cs
@@ -58,5 +58,10 @@ namespace FluentAssertions.Equivalency
         /// Gets a value indicating whether properties should be considered.
         /// </summary>
         bool IncludeProperties { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether fields should be considered.
+        /// </summary>
+        bool IncludeFields { get; }
     }
 }

--- a/FluentAssertions.Core/Equivalency/ISelectedMemberInfo.cs
+++ b/FluentAssertions.Core/Equivalency/ISelectedMemberInfo.cs
@@ -23,7 +23,7 @@ namespace FluentAssertions.Equivalency
         Type DeclaringType { get; }
 
         /// <summary>
-        /// Returns the property value of a specified object with optional index values for indexed properties or methods.
+        /// Returns the member value of a specified object with optional index values for indexed properties or methods.
         /// </summary>
         object GetValue(object obj, object[] index);
     }

--- a/FluentAssertions.Core/Equivalency/MatchAllOrderingRule.cs
+++ b/FluentAssertions.Core/Equivalency/MatchAllOrderingRule.cs
@@ -5,6 +5,9 @@ namespace FluentAssertions.Equivalency
     /// </summary>
     internal class MatchAllOrderingRule : IOrderingRule
     {
+        /// <summary>
+        /// Determines if ordering of the member refered to by the current <paramref name="subjectInfo"/> is relevant.
+        /// </summary>
         public bool AppliesTo(ISubjectInfo subjectInfo)
         {
             return true;

--- a/FluentAssertions.Core/Equivalency/MustMatchByNameRule.cs
+++ b/FluentAssertions.Core/Equivalency/MustMatchByNameRule.cs
@@ -18,6 +18,12 @@ namespace FluentAssertions.Equivalency
                     .FindProperty(subjectMember.Name, subjectMember.MemberType));
             }
 
+            if ((compareeSelectedMemberInfoInfo == null) && config.IncludeFields)
+            {
+                compareeSelectedMemberInfoInfo = SelectedMemberInfo.Create(expectation.GetType()
+                    .FindField(subjectMember.Name, subjectMember.MemberType));
+            }
+
             if ((compareeSelectedMemberInfoInfo == null) && ExpectationImplementsMemberExplicitly(expectation, subjectMember))
             {
                 compareeSelectedMemberInfoInfo = subjectMember;

--- a/FluentAssertions.Net40/ObjectAssertionsExtensions.cs
+++ b/FluentAssertions.Net40/ObjectAssertionsExtensions.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions
     {
         /// <summary>
         /// Asserts that an object can be serialized and deserialized using the binary serializer and that it stills retains
-        /// the values of all properties.
+        /// the values of all members.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
@@ -30,7 +30,7 @@ namespace FluentAssertions
 
         /// <summary>
         /// Asserts that an object can be serialized and deserialized using the binary serializer and that it stills retains
-        /// the values of all properties.
+        /// the values of all members.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
@@ -48,7 +48,7 @@ namespace FluentAssertions
                 object deserializedObject = CreateCloneUsingBinarySerializer(assertions.Subject);
 
                 EquivalencyAssertionOptions<T> defaultOptions = new EquivalencyAssertionOptions<T>()
-                    .IncludingAllRuntimeProperties();
+                    .IncludingAllRuntimeMembers();
 
                 ((T)deserializedObject).ShouldBeEquivalentTo(assertions.Subject, _ => options(defaultOptions));
             }
@@ -76,7 +76,7 @@ namespace FluentAssertions
 
         /// <summary>
         /// Asserts that an object can be serialized and deserialized using the XML serializer and that it stills retains
-        /// the values of all properties.
+        /// the values of all members.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
@@ -93,7 +93,7 @@ namespace FluentAssertions
                 object deserializedObject = CreateCloneUsingXmlSerializer(assertions.Subject);
 
                 deserializedObject.ShouldBeEquivalentTo(assertions.Subject,
-                    options => options.IncludingAllRuntimeProperties());
+                    options => options.IncludingAllRuntimeMembers());
             }
             catch (Exception exc)
             {

--- a/FluentAssertions.Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/CollectionEquivalencySpecs.cs
@@ -118,7 +118,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                     collection1.ShouldBeEquivalentTo(collection2,
-                        opts => opts.IncludingAllRuntimeProperties());
+                        opts => opts.IncludingAllRuntimeMembers());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -229,7 +229,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                     collection1.ShouldBeEquivalentTo(collection2,
-                        opts => opts.IncludingAllRuntimeProperties());
+                        opts => opts.IncludingAllRuntimeMembers());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -274,7 +274,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.IncludingAllRuntimeProperties());
+                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.IncludingAllRuntimeMembers());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -319,7 +319,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.IncludingAllRuntimeProperties());
+                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.IncludingAllRuntimeMembers());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/FluentAssertions.Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/CollectionEquivalencySpecs.cs
@@ -560,7 +560,7 @@ namespace FluentAssertions.Specs
                 () =>
                     subject.ShouldAllBeEquivalentTo(expectation,
                         options => options
-                            .ExcludingMissingProperties()
+                            .ExcludingMissingMembers()
                             .Excluding(c => c.Age));
 
             //-----------------------------------------------------------------------------------------------------------

--- a/FluentAssertions.Shared.Specs/DictionaryEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/DictionaryEquivalencySpecs.cs
@@ -52,7 +52,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                 dictionary1.ShouldBeEquivalentTo(dictionary2,
-                    opts => opts.IncludingAllRuntimeProperties());
+                    opts => opts.IncludingAllRuntimeMembers());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -92,7 +92,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.IncludingAllRuntimeProperties());
+            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.IncludingAllRuntimeMembers());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -395,7 +395,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.IncludingAllRuntimeProperties());
+            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.IncludingAllRuntimeMembers());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -438,7 +438,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                 dictionary1.ShouldBeEquivalentTo(dictionary2,
-                    opts => opts.IncludingAllRuntimeProperties());
+                    opts => opts.IncludingAllRuntimeMembers());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/FluentAssertions.Shared.Specs/FormatterSpecs.cs
+++ b/FluentAssertions.Shared.Specs/FormatterSpecs.cs
@@ -211,10 +211,40 @@ namespace FluentAssertions.Specs
             result.Should().ContainEquivalentOf("maximum recursion depth");
         }
 
+        [TestMethod]
+        public void When_formatting_with_default_behavior_it_should_include_non_private_fields()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var stuffWithAField = new StuffWithAField {Field = "Some Text"};
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            string result = Formatter.ToString(stuffWithAField);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            result.Should().Contain("Field").And.Contain("Some Text");
+            result.Should().NotContain("privateField");
+        }
+
         public class BaseStuff
         {
             public int StuffId { get; set; }
             public string Description { get; set; }
+        }
+
+        public class StuffWithAField
+        {
+            public int StuffId { get; set; }
+            public string Description { get; set; }
+            public string Field;
+#pragma warning disable 169
+            private string privateField;
+#pragma warning restore 169
         }
 
         public class Stuff<TChild> : BaseStuff

--- a/FluentAssertions.Shared.Specs/ObjectAssertionSpecs.cs
+++ b/FluentAssertions.Shared.Specs/ObjectAssertionSpecs.cs
@@ -454,7 +454,8 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             var subject = new SerializableClass
             {
-                Name = "John"
+                Name = "John",
+                Id = 2
             };
 
             //-----------------------------------------------------------------------------------------------------------
@@ -581,6 +582,8 @@ namespace FluentAssertions.Specs
         public class SerializableClass
         {
             public string Name { get; set; }
+
+            public int Id;
         }
 
         [Serializable]
@@ -642,7 +645,8 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             var subject = new XmlSerializableClass
             {
-                Name = "John"
+                Name = "John",
+                Id = 1
             };
 
             //-----------------------------------------------------------------------------------------------------------
@@ -717,6 +721,8 @@ namespace FluentAssertions.Specs
         public class XmlSerializableClass
         {
             public string Name { get; set; }
+
+            public int Id;
         }
 
         public class XmlSerializableClassNotRestoringAllProperties : IXmlSerializable


### PR DESCRIPTION
This should resolve Issue #22.

In addition to including Fields in `ShouldBeEquivalentTo` it also makes the Binary and XML Serialization assertions check fields.

Not sure if there is any etiquette or practices around this, but I did not include the full history of my work thinking this was cleaner.