### PR TITLE
Fix issue 194

### DIFF
--- a/FluentAssertions.Core/Common/ExpressionExtensions.cs
+++ b/FluentAssertions.Core/Common/ExpressionExtensions.cs
@@ -139,5 +139,10 @@ namespace FluentAssertions.Common
         {
             return GetMemberPath(propertyExpression);
         }
+
+        internal static string GetMethodName(Expression<Action> action)
+        {
+            return ((MethodCallExpression)action.Body).Method.Name;
+        }
     }
 }

--- a/FluentAssertions.Core/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
+using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency
@@ -116,7 +117,8 @@ namespace FluentAssertions.Equivalency
 
         private static bool AssertSameLength(object subject, Type subjectType, object expectation)
         {
-            string methodName = GetMethodName(() => AssertSameLength<object, object, object, object>(null, null));
+            string methodName =
+                ExpressionExtensions.GetMethodName(() => AssertSameLength<object, object, object, object>(null, null));
 
             MethodCallExpression assertSameLength = Expression.Call(
                 typeof(GenericDictionaryEquivalencyStep),
@@ -128,11 +130,6 @@ namespace FluentAssertions.Equivalency
                 Expression.Constant(expectation, GetIDictionaryInterface(expectation.GetType())));
 
             return (bool)Expression.Lambda(assertSameLength).Compile().DynamicInvoke();
-        }
-
-        private static string GetMethodName(Expression<Action> action)
-        {
-            return ((MethodCallExpression)action.Body).Method.Name;
         }
 
         private static IEnumerable<Type> GetDictionaryTypeArguments(Type subjectType)
@@ -167,7 +164,7 @@ namespace FluentAssertions.Equivalency
             Type subjectType = config.GetSubjectType(context);
 
             string methodName =
-                GetMethodName(
+                ExpressionExtensions.GetMethodName(
                     () => AssertDictionaryEquivalence<object, object, object, object>(null, null, null, null, null));
 
             var assertDictionaryEquivalence = Expression.Call(

--- a/FluentAssertions.Core/Equivalency/GenericEnumerableEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/GenericEnumerableEquivalencyStep.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
+using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency
@@ -66,7 +67,7 @@ namespace FluentAssertions.Equivalency
 
                 MethodCallExpression executeExpression = Expression.Call(
                     Expression.Constant(validator),
-                    "Execute",
+                    ExpressionExtensions.GetMethodName(() => validator.Execute<object>(null,null)),
                     new Type[] { typeOfEnumeration },
                     subjectToArray,
                     expectationToArray);

--- a/FluentAssertions.Core/Equivalency/ShouldAllBeEquivalentToHelper.cs
+++ b/FluentAssertions.Core/Equivalency/ShouldAllBeEquivalentToHelper.cs
@@ -15,7 +15,7 @@ namespace FluentAssertions.Equivalency
             EquivalencyAssertionOptions<TSubject> optionsToConfigure,
             Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> subConfig)
         {
-            var options = new EquivalencyAssertionOptions<T>();
+            EquivalencyAssertionOptions<T> options = EquivalencyAssertionOptions<T>.Default();
             options = subConfig(options);
 
             ConfigureOrderingRules(optionsToConfigure, options);
@@ -47,8 +47,7 @@ namespace FluentAssertions.Equivalency
                 actualOptions.WithoutSelectionRules();
             }
 
-            //Reverse order because Using prepends
-            foreach (var selectionRule in opts.SelectionRules.Reverse())
+            foreach (var selectionRule in opts.SelectionRules)
             {
                 actualOptions.Using(new CollectionMemberSelectionRuleDecorator(selectionRule));
             }

--- a/FluentAssertions.sln.DotSettings
+++ b/FluentAssertions.sln.DotSettings
@@ -5,6 +5,8 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Int64 x:Key="/Default/Environment/UnitTesting/ParallelProcessesCount/@EntryValue">4</s:Int64>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/@KeyIndexDefined">True</s:Boolean>


### PR DESCRIPTION
Correct issues wherein ShouldAllBeEquivalentTo would lack the default SelectionRule and would apply the selection rules in the revere order.  This is the issue reported by #194.