### PR TITLE
Different API for including fields

### DIFF
--- a/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptions.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptions.cs
@@ -105,7 +105,7 @@ namespace FluentAssertions.Equivalency
             IncludingFields();
             IncludingProperties();
 
-            RespectingDeclaredType();
+            RespectingDeclaredTypes();
         }
     }
 }

--- a/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptions.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptions.cs
@@ -101,7 +101,11 @@ namespace FluentAssertions.Equivalency
         public EquivalencyAssertionOptions()
         {
             IncludingNestedObjects();
-            IncludingAllDeclaredMembers();
+
+            IncludingFields();
+            IncludingProperties();
+
+            RespectingDeclaredType();
         }
     }
 }

--- a/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptionsBase.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptionsBase.cs
@@ -198,7 +198,7 @@ namespace FluentAssertions.Equivalency
         /// </remarks>
         public TSelf IncludingAllDeclaredProperties()
         {
-            RespectingDeclaredType();
+            RespectingDeclaredTypes();
 
             ExcludingFields();
             IncludingProperties();
@@ -216,7 +216,7 @@ namespace FluentAssertions.Equivalency
         /// </remarks>
         public TSelf IncludingAllRuntimeProperties()
         {
-            RespectingRuntimeType();
+            RespectingRuntimeTypes();
 
             ExcludingFields();
             IncludingProperties();
@@ -277,7 +277,7 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Instructs the comparison to respect the subject's runtime type.
         /// </summary>
-        public TSelf RespectingRuntimeType()
+        public TSelf RespectingRuntimeTypes()
         {
             useRuntimeTyping = true;
             return (TSelf)this;
@@ -286,7 +286,7 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Instructs the comparison to respect the subject's declared type.
         /// </summary>
-        public TSelf RespectingDeclaredType()
+        public TSelf RespectingDeclaredTypes()
         {
             useRuntimeTyping = false;
             return (TSelf)this;
@@ -535,7 +535,7 @@ namespace FluentAssertions.Equivalency
         {
             selectionRules.Clear();
 
-            RespectingDeclaredType();
+            RespectingDeclaredTypes();
             IncludingFields();
             IncludingProperties();
         }

--- a/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptionsBase.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptionsBase.cs
@@ -44,6 +44,11 @@ namespace FluentAssertions.Equivalency
 
         private bool includeFields;
 
+        /// <summary>
+        /// A value indicating whether the default selection rules need to be prepended or not.
+        /// </summary>
+        private bool mustAddSelectionRules = true;
+
         #endregion
 
         internal EquivalencyAssertionOptionsBase()
@@ -67,10 +72,39 @@ namespace FluentAssertions.Equivalency
             includeProperties = defaults.IncludeProperties;
             includeFields = defaults.IncludeFields;
 
-            selectionRules.AddRange(defaults.SelectionRules);
+            selectionRules.AddRange(defaults.SelectionRules.Where(IsNotStandardSelectionRule));
+
+            if (IncludesIncludingSelectionRule(defaults.SelectionRules))
+            {
+                mustAddSelectionRules = false;
+            }
+
             userEquivalencySteps.AddRange(defaults.UserEquivalencySteps);
             matchingRules.AddRange(defaults.MatchingRules);
             orderingRules = new OrderingRuleCollection(defaults.OrderingRules);
+        }
+
+        private static bool IncludesIncludingSelectionRule(IEnumerable<IMemberSelectionRule> memberSelectionRules)
+        {
+            Type[] standardIncludingSelectionRules =
+            {
+                typeof (IncludeMemberByPredicateSelectionRule),
+                typeof (IncludeMemberByPathSelectionRule)
+            };
+
+            return memberSelectionRules.Any(
+                selectionRule => standardIncludingSelectionRules.Contains(selectionRule.GetType()));
+        }
+
+        private static bool IsNotStandardSelectionRule(IMemberSelectionRule selectionRule)
+        {
+            Type[] standardSelectionRules =
+            {
+                typeof (AllPublicFieldsSelectionRule),
+                typeof (AllPublicPropertiesSelectionRule)
+            };
+
+            return !standardSelectionRules.Contains(selectionRule.GetType());
         }
 
         /// <summary>
@@ -78,7 +112,15 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         IEnumerable<IMemberSelectionRule> IEquivalencyAssertionOptions.SelectionRules
         {
-            get { return selectionRules; }
+            get
+            {
+                if (mustAddSelectionRules)
+                {
+                    return CreateSelectionRules().Concat(selectionRules).ToArray();
+                }
+
+                return selectionRules;
+            }
         }
 
         /// <summary>
@@ -151,6 +193,9 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Causes inclusion of only public properties of the subject as far as they are defined on the declared type. 
         /// </summary>
+        /// <remarks>
+        /// This clears all previously registered selection rules.
+        /// </remarks>
         public TSelf IncludingAllDeclaredProperties()
         {
             RespectingDeclaredType();
@@ -166,6 +211,9 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         ///  Causes inclusion of only public properties of the subject based on its run-time type rather than its declared type.
         /// </summary>
+        /// <remarks>
+        ///  This clears all previously registered selection rules.
+        /// </remarks>
         public TSelf IncludingAllRuntimeProperties()
         {
             RespectingRuntimeType();
@@ -179,96 +227,66 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        ///  Causes inclusion of only public fields of the subject as far as they are defined on the declared type. 
+        ///  Instructs the comparison to include fields. 
         /// </summary>
-        public TSelf IncludingAllDeclaredFields()
-        {
-            RespectingDeclaredType();
-
-            IncludingFields();
-            ExcludingProperties();
-
-            ReconfigureSelectionRules();
-
-            return (TSelf)this;
-        }
-
-        /// <summary>
-        ///  Causes inclusion of only public fields of the subject based on its run-time type rather than its declared type.
-        /// </summary>
-        public TSelf IncludingAllRuntimeFields()
-        {
-            RespectingRuntimeType();
-
-            IncludingFields();
-            ExcludingProperties();
-
-            ReconfigureSelectionRules();
-
-            return (TSelf)this;
-        }
-        
-        /// <summary>
-        ///  Causes inclusion of only public members of the subject as far as they are defined on the declared type. 
-        /// </summary>
-        public TSelf IncludingAllDeclaredMembers()
-        {
-            RespectingDeclaredType();
-
-            IncludingFields();
-            IncludingProperties();
-
-            ReconfigureSelectionRules();
-
-            return (TSelf)this;
-        }
-
-        /// <summary>
-        ///  Causes inclusion of only public members of the subject based on its run-time type rather than its declared type.
-        /// </summary>
-        public TSelf IncludingAllRuntimeMembers()
-        {
-            RespectingRuntimeType();
-
-            IncludingFields();
-            IncludingProperties();
-
-            ReconfigureSelectionRules();
-
-            return (TSelf)this;
-        }
-
-        private TSelf IncludingFields()
+        /// <remarks>
+        ///  This is part of the default behavior.
+        /// </remarks>
+        public TSelf IncludingFields()
         {
             includeFields = true;
             return (TSelf)this;
         }
 
-        private TSelf ExcludingFields()
+        /// <summary>
+        ///  Instructs the comparison to exclude fields. 
+        /// </summary>
+        /// <remarks>
+        ///  This does not preclude use of `Including`.
+        /// </remarks>
+        public TSelf ExcludingFields()
         {
             includeFields = false;
             return (TSelf)this;
         }
 
-        private TSelf IncludingProperties()
+        /// <summary>
+        ///  Instructs the comparison to include properties.  
+        /// </summary>
+        /// <remarks>
+        ///  This is part of the default behavior.
+        /// </remarks>
+        public TSelf IncludingProperties()
         {
             includeProperties = true;
             return (TSelf)this;
         }
 
-        private TSelf ExcludingProperties()
+        /// <summary>
+        ///  Instructs the comparison to exclude properties. 
+        /// </summary>
+        /// <remarks>
+        ///  This does not preclude use of `Including`.
+        /// </remarks>
+        public TSelf ExcludingProperties()
         {
             includeProperties = false;
             return (TSelf)this;
         }
 
-        private TSelf RespectingRuntimeType()
+        /// <summary>
+        /// Instructs the comparison to respect the subject's runtime type.
+        /// </summary>
+        public TSelf RespectingRuntimeType()
         {
             useRuntimeTyping = true;
             return (TSelf)this;
         }
 
-        private TSelf RespectingDeclaredType()
+        /// <summary>
+        /// Instructs the comparison to respect the subject's declared type.
+        /// </summary>
+        public TSelf RespectingDeclaredType()
         {
             useRuntimeTyping = false;
             return (TSelf)this;
@@ -410,18 +428,30 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Adds a selection rule to the ones already added by default, and which is evaluated after all existing rules.
         /// </summary>
+        /// <remarks>
+        /// Using this method will cause all fields to be excluded. 
+        /// </remarks>
         [Obsolete("This method will be removed in a future version.  Use `Using(IMemberSelectionRule)` instead.")]
         public TSelf Using(ISelectionRule selectionRule)
         {
+            // The adapter forces the exclusion, but explicitly stating it here for clarity
+            // and in case any thing external looks at the configuration setting
+            ExcludingFields();
             return AddSelectionRule(new ObsoleteSelectionRuleAdapter(selectionRule));
         }
 
         /// <summary>
         /// Adds a matching rule to the ones already added by default, and which is evaluated before all existing rules.
         /// </summary>
+        /// <remarks>
+        /// Using this method will cause all fields to be excluded. 
+        /// </remarks>
         [Obsolete("This method will be removed in a future version.  Use `Using(IMemberMatchingRule)` instead.")]
         public TSelf Using(IMatchingRule matchingRule)
         {
+            // The adapter forces the exclusion, but explicitly stating it here for clarity
+            // and in case any thing external looks at the configuration setting
+            ExcludingFields();
             return AddMatchingRule(new ObsoleteMatchingRuleAdapter(matchingRule));
         }
 
@@ -498,12 +528,7 @@ namespace FluentAssertions.Equivalency
 
         protected void RemoveStandardSelectionRules()
         {
-            RemoveSelectionRule<AllPublicPropertiesSelectionRule>();
-            RemoveSelectionRule<AllPublicFieldsSelectionRule>();
-
-            RespectingDeclaredType();
-            IncludingFields();
-            IncludingProperties();
+            mustAddSelectionRules = false;
         }
 
         private void ClearSelectionRules()
@@ -542,7 +567,7 @@ namespace FluentAssertions.Equivalency
         {
             selectionRules.Clear();
 
-            selectionRules.AddRange(CreateSelectionRules());
+            mustAddSelectionRules = true;
         }
 
         private IEnumerable<IMemberSelectionRule> CreateSelectionRules()

--- a/FluentAssertions.Net40/ObjectAssertionsExtensions.cs
+++ b/FluentAssertions.Net40/ObjectAssertionsExtensions.cs
@@ -47,8 +47,8 @@ namespace FluentAssertions
             {
                 object deserializedObject = CreateCloneUsingBinarySerializer(assertions.Subject);
 
-                EquivalencyAssertionOptions<T> defaultOptions = new EquivalencyAssertionOptions<T>()
-                    .IncludingAllRuntimeMembers();
+                EquivalencyAssertionOptions<T> defaultOptions = EquivalencyAssertionOptions<T>.Default()
+                    .RespectingRuntimeType().IncludingFields().IncludingProperties();
 
                 ((T)deserializedObject).ShouldBeEquivalentTo(assertions.Subject, _ => options(defaultOptions));
             }
@@ -93,7 +93,7 @@ namespace FluentAssertions
                 object deserializedObject = CreateCloneUsingXmlSerializer(assertions.Subject);
 
                 deserializedObject.ShouldBeEquivalentTo(assertions.Subject,
-                    options => options.IncludingAllRuntimeMembers());
+                    options => options.RespectingRuntimeType().IncludingFields().IncludingProperties());
             }
             catch (Exception exc)
             {

--- a/FluentAssertions.Net40/ObjectAssertionsExtensions.cs
+++ b/FluentAssertions.Net40/ObjectAssertionsExtensions.cs
@@ -48,7 +48,7 @@ namespace FluentAssertions
                 object deserializedObject = CreateCloneUsingBinarySerializer(assertions.Subject);
 
                 EquivalencyAssertionOptions<T> defaultOptions = EquivalencyAssertionOptions<T>.Default()
-                    .RespectingRuntimeType().IncludingFields().IncludingProperties();
+                    .RespectingRuntimeTypes().IncludingFields().IncludingProperties();
 
                 ((T)deserializedObject).ShouldBeEquivalentTo(assertions.Subject, _ => options(defaultOptions));
             }
@@ -93,7 +93,7 @@ namespace FluentAssertions
                 object deserializedObject = CreateCloneUsingXmlSerializer(assertions.Subject);
 
                 deserializedObject.ShouldBeEquivalentTo(assertions.Subject,
-                    options => options.RespectingRuntimeType().IncludingFields().IncludingProperties());
+                    options => options.RespectingRuntimeTypes().IncludingFields().IncludingProperties());
             }
             catch (Exception exc)
             {

--- a/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
@@ -1091,7 +1091,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => class1.ShouldBeEquivalentTo(class2, opts => opts.ExcludingProperties().RespectingRuntimeType());
+                () => class1.ShouldBeEquivalentTo(class2, opts => opts.ExcludingProperties().RespectingRuntimeTypes());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -1213,7 +1213,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => class1.ShouldBeEquivalentTo(class2, opts => opts.RespectingRuntimeType());
+                () => class1.ShouldBeEquivalentTo(class2, opts => opts.RespectingRuntimeTypes());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
@@ -242,7 +242,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => onlyAField.ShouldBeEquivalentTo(onlyAProperty, opts => opts.IncludingAllDeclaredFields());
+            Action act = () => onlyAField.ShouldBeEquivalentTo(onlyAProperty, opts => opts.ExcludingProperties());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -1040,7 +1040,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_using_IncludingAllDeclaredFields_properties_should_be_ignored()
+        public void When_excluding_properties_it_should_still_compare_fields()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -1055,22 +1055,22 @@ namespace FluentAssertions.Specs
                 Property3 = "consectetur"
             };
 
-            var class2 = new ClassWithSomeFieldsAndProperties { Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor" };
+            var class2 = new ClassWithSomeFieldsAndProperties { Field1 = "Lorem", Field2 = "ipsum", Field3 = "color" };
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => class1.ShouldBeEquivalentTo(class2, opts => opts.IncludingAllDeclaredFields());
+                () => class1.ShouldBeEquivalentTo(class2, opts => opts.ExcludingProperties());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.ShouldNotThrow();
+            act.ShouldThrow<AssertFailedException>().WithMessage("*color*dolor*");
         }
 
         [TestMethod]
-        public void When_using_IncludingAllRuntimeFields_the_runtime_type_should_be_used_and_properties_should_be_ignored()
+        public void When_configured_for_runtime_typing_and_properties_are_excluded_the_runtime_type_should_be_used_and_properties_should_be_ignored()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -1091,7 +1091,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => class1.ShouldBeEquivalentTo(class2, opts => opts.IncludingAllRuntimeFields());
+                () => class1.ShouldBeEquivalentTo(class2, opts => opts.ExcludingProperties().RespectingRuntimeType());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -1170,7 +1170,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_using_IncludingAllDeclaredMembers_and_both_properties_and_fields_included()
+        public void When_both_field_and_properties_are_configured_for_inclusion_both_should_be_included()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -1187,7 +1187,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => class1.ShouldBeEquivalentTo(class2, opts => opts.IncludingAllDeclaredMembers());
+                () => class1.ShouldBeEquivalentTo(class2, opts => opts.IncludingFields().IncludingProperties());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -1196,7 +1196,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_using_IncludingAllRuntimeMembers_the_runtime_type_should_be_used_and_both_properties_and_fields_included()
+        public void When_respecting_the_runtime_type_is_configured_the_runtime_type_should_be_used_and_both_properties_and_fields_included()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -1213,7 +1213,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => class1.ShouldBeEquivalentTo(class2, opts => opts.IncludingAllRuntimeMembers());
+                () => class1.ShouldBeEquivalentTo(class2, opts => opts.RespectingRuntimeType());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -2748,7 +2748,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.IncludingAllDeclaredFields());
+            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.ExcludingProperties());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/FluentAssertions.Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/CollectionEquivalencySpecs.cs
@@ -119,7 +119,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                     collection1.ShouldBeEquivalentTo(collection2,
-                        opts => opts.RespectingRuntimeType());
+                        opts => opts.RespectingRuntimeTypes());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -230,7 +230,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                     collection1.ShouldBeEquivalentTo(collection2,
-                        opts => opts.RespectingRuntimeType());
+                        opts => opts.RespectingRuntimeTypes());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -275,7 +275,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.RespectingRuntimeType());
+                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.RespectingRuntimeTypes());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -320,7 +320,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.RespectingRuntimeType());
+                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.RespectingRuntimeTypes());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/FluentAssertions.Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/CollectionEquivalencySpecs.cs
@@ -119,7 +119,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                     collection1.ShouldBeEquivalentTo(collection2,
-                        opts => opts.IncludingAllRuntimeMembers());
+                        opts => opts.RespectingRuntimeType());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -215,7 +215,7 @@ namespace FluentAssertions.Specs
 
         [TestMethod]
         public void
-            When_asserting_equivalence_of_generic_collections_and_configured_to_use_runtime_properties_it_should_respect_the_runtime_type
+            When_asserting_equivalence_of_generic_collections_and_configured_to_use_runtime_type_information_it_should_respect_the_runtime_type
             ()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -230,7 +230,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                     collection1.ShouldBeEquivalentTo(collection2,
-                        opts => opts.IncludingAllRuntimeMembers());
+                        opts => opts.RespectingRuntimeType());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -275,7 +275,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.IncludingAllRuntimeMembers());
+                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.RespectingRuntimeType());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -320,7 +320,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act =
-                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.IncludingAllRuntimeMembers());
+                () => collection1.ShouldBeEquivalentTo(collection2, opts => opts.RespectingRuntimeType());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/FluentAssertions.Shared.Specs/DictionaryEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/DictionaryEquivalencySpecs.cs
@@ -52,7 +52,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                 dictionary1.ShouldBeEquivalentTo(dictionary2,
-                    opts => opts.RespectingRuntimeType());
+                    opts => opts.RespectingRuntimeTypes());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -92,7 +92,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.RespectingRuntimeType());
+            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.RespectingRuntimeTypes());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -395,7 +395,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.RespectingRuntimeType());
+            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.RespectingRuntimeTypes());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -438,7 +438,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                 dictionary1.ShouldBeEquivalentTo(dictionary2,
-                    opts => opts.RespectingRuntimeType());
+                    opts => opts.RespectingRuntimeTypes());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/FluentAssertions.Shared.Specs/DictionaryEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/DictionaryEquivalencySpecs.cs
@@ -38,7 +38,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_equivalence_of_dictionaries_and_configured_to_use_runtime_properties_it_should_respect_the_runtime_type()
+        public void When_asserting_equivalence_of_dictionaries_and_configured_to_respect_runtime_type_it_should_respect_the_runtime_type()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -52,7 +52,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                 dictionary1.ShouldBeEquivalentTo(dictionary2,
-                    opts => opts.IncludingAllRuntimeMembers());
+                    opts => opts.RespectingRuntimeType());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -92,7 +92,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.IncludingAllRuntimeMembers());
+            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.RespectingRuntimeType());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -395,7 +395,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.IncludingAllRuntimeMembers());
+            Action act = () => object1.ShouldBeEquivalentTo(object2, opts => opts.RespectingRuntimeType());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -438,7 +438,7 @@ namespace FluentAssertions.Specs
             Action act =
                 () =>
                 dictionary1.ShouldBeEquivalentTo(dictionary2,
-                    opts => opts.IncludingAllRuntimeMembers());
+                    opts => opts.RespectingRuntimeType());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert


### PR DESCRIPTION
Switches to a more granular API for specifying runtime/declared typing and inclusion of properties/fields in ShouldBeEquivalentTo.

The thinking is this API will work better with the global configuration being introduced for #137.  The idea being global configuration could specify `ExcludingFields()` and a test just wanting runtime typing only needs to specify `RespectingRuntimeTypes()` and not need to possibly override the `ExcludingFields()` configuration.