### PR TITLE
Include timezone offset in DateTimeOffset display

### DIFF
--- a/FluentAssertions.Core/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/FluentAssertions.Core/Formatting/DateTimeOffsetValueFormatter.cs
@@ -84,18 +84,25 @@ namespace FluentAssertions.Formatting
             if (offset == TimeSpan.Zero)
                 return "UTC";
 
-            var sign = offset < TimeSpan.Zero ? "-" : "+";
-            var absoluteOffset = offset < TimeSpan.Zero ? -offset : offset;
-            string offsetStr;
+            var absoluteOffset = (offset < TimeSpan.Zero) ? -offset : offset;
+
+            string formattedOffset;
 
             if (absoluteOffset.Ticks == absoluteOffset.Hours * TimeSpan.TicksPerHour)
-                offsetStr = absoluteOffset.Hours.ToString();
+            {
+                formattedOffset = absoluteOffset.Hours.ToString();
+            }
             else if (absoluteOffset.Ticks == absoluteOffset.Hours * TimeSpan.TicksPerHour + absoluteOffset.Minutes * TimeSpan.TicksPerMinute)
-                offsetStr = string.Format("{0}:{1:00}", absoluteOffset.Hours, absoluteOffset.Minutes);
+            {
+                formattedOffset = string.Format("{0}:{1:00}", absoluteOffset.Hours, absoluteOffset.Minutes);
+            }
             else
+            {
                 throw new ArgumentException("Offset is supposed to be in whole minutes");
+            }
 
-            return "UTC" + sign + offsetStr;
+            var sign = (offset < TimeSpan.Zero) ? "-" : "+";
+            return "UTC" + sign + formattedOffset;
         }
 
         private static bool HasTime(DateTimeOffset dateTime)

--- a/FluentAssertions.Core/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/FluentAssertions.Core/Formatting/DateTimeOffsetValueFormatter.cs
@@ -79,10 +79,14 @@ namespace FluentAssertions.Formatting
         private string FormatOffset(TimeSpan offset)
         {
             if (offset == TimeZoneOffset)
+            {
                 return null;
+            }
 
             if (offset == TimeSpan.Zero)
+            {
                 return "UTC";
+            }
 
             var absoluteOffset = (offset < TimeSpan.Zero) ? -offset : offset;
 
@@ -92,7 +96,7 @@ namespace FluentAssertions.Formatting
             {
                 formattedOffset = absoluteOffset.Hours.ToString();
             }
-            else if (absoluteOffset.Ticks == absoluteOffset.Hours * TimeSpan.TicksPerHour + absoluteOffset.Minutes * TimeSpan.TicksPerMinute)
+            else if (absoluteOffset.Ticks == (absoluteOffset.Hours * TimeSpan.TicksPerHour) + (absoluteOffset.Minutes * TimeSpan.TicksPerMinute))
             {
                 formattedOffset = string.Format("{0}:{1:00}", absoluteOffset.Hours, absoluteOffset.Minutes);
             }

--- a/FluentAssertions.Shared.Specs/DateTimeOffsetValueFormatterSpecs.cs
+++ b/FluentAssertions.Shared.Specs/DateTimeOffsetValueFormatterSpecs.cs
@@ -95,6 +95,48 @@ namespace FluentAssertions.Specs
 
         [TestMethod]
         public void
+            When_a_DateTimeOffset_is_formatted_it_should_mention_offset()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var nonUtcFormatter = new DateTimeOffsetValueFormatter { TimeZoneOffset = TimeSpan.FromHours(8) };
+            var utcFormatter = new DateTimeOffsetValueFormatter { TimeZoneOffset = TimeSpan.Zero };
+
+            Func<DateTimeOffset, string> formatNonUtc = value => nonUtcFormatter.ToString(value, false);
+            Func<DateTimeOffset, string> formatUtc = value => utcFormatter.ToString(value, false);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            formatNonUtc(new DateTimeOffset(2015, 11, 15, 0, 0, 0, TimeSpan.FromHours(13))).Should().Be("<2015-11-15 UTC+13>");
+            formatNonUtc(new DateTimeOffset(2015, 11, 1, 21, 0, 0, -TimeSpan.FromHours(1))).Should().Be("<2015-11-01 21:00:00 UTC-1>");
+            formatNonUtc(new DateTimeOffset(2014, 12, 30, 15, 41, 58, -new TimeSpan(7, 2, 0))).Should().Be("<2014-12-30 15:41:58 UTC-7:02>");
+            formatNonUtc(new DateTimeOffset(2014, 12, 30, 0, 0, 0, new TimeSpan(8, 48, 0))).Should().Be("<2014-12-30 UTC+8:48>");
+            formatNonUtc(new DateTimeOffset(1996, 3, 8, 11, 35, 14, TimeSpan.Zero)).Should().Be("<1996-03-08 11:35:14 UTC>");
+            formatNonUtc(new DateTimeOffset(2015, 11, 15, 0, 0, 0, TimeSpan.FromHours(8))).Should().Be("<2015-11-15>");
+
+            formatUtc(new DateTimeOffset(1987, 3, 15, 13, 16, 19, TimeSpan.Zero)).Should().Be("<1987-03-15 13:16:19>");
+            formatUtc(new DateTimeOffset(2015, 11, 15, 0, 0, 0, TimeSpan.FromHours(8))).Should().Be("<2015-11-15 UTC+8>");
+        }
+
+        [TestMethod]
+        public void
+            When_a_DateTimeOffsetValueFormatter_is_created_it_should_default_TimeZoneOffset_to_current_local()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var formatter = new DateTimeOffsetValueFormatter();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            formatter.TimeZoneOffset.Should().Be(TimeZoneInfo.Local.BaseUtcOffset);
+        }
+
+        [TestMethod]
+        public void
             When_a_DateTime_is_used_it_should_format_the_same_as_a_DateTimeOffset()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -102,10 +144,10 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             var formatter = new DateTimeOffsetValueFormatter();
 
-            var dateOnly = ToUtcWithoutChangingTime(new DateTime(1973, 9, 20));
-            var timeOnly = ToUtcWithoutChangingTime(1.January(0001).At(08, 20, 01));
-            var witoutMilliseconds = ToUtcWithoutChangingTime(1.May(2012).At(20, 15, 30));
-            var withMilliseconds = ToUtcWithoutChangingTime(1.May(2012).At(20, 15, 30, 318));
+            var dateOnly = new DateTime(1973, 9, 20);
+            var timeOnly = 1.January(0001).At(08, 20, 01);
+            var witoutMilliseconds = 1.May(2012).At(20, 15, 30);
+            var withMilliseconds = 1.May(2012).At(20, 15, 30, 318);
 
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert


### PR DESCRIPTION
Right now comparing two DateTimeOffset with different time zones might lead to an unclear error message:

    var expected = new DateTimeOffset(2013, 1, 10, 2, 0, 0, 0, TimeSpan.FromHours(5));
    var actual   = new DateTimeOffset(2013, 1, 10, 2, 0, 0, 0, TimeSpan.FromHours(6));  // Different offset
    actual.Should().Be(expected);

results in:

    Expected date and time to be <2013-01-10 02:00:00>, but found <2013-01-10 02:00:00>.

This error message seems to be saying that the values match but the test has still failed. To make the difference more clear I've added timezone offset information into DateTimeOffset formatting code.

To avoid wider changes, the offset is not included if it matches the current timezone offset. The test *When_a_DateTime_is_used_it_should_format_the_same_as_a_DateTimeOffset* was failing because it compares formatting of UTC and Local values so I couldn't avoid changing it to have all the dates as **DateTimeKind.Unspecified**.

Overall I think the way UTC, Unspecified and Local are handled in *FluentAssertions* is too forgiving. At least **DateTimeExtensions.ToDateTimeOffset** shouldn't force UTC values to be Local (this is what caused the test above to fail). I would even argue to extracxt *DateTimeAssertions* from *DateTimeOffsetAssertions* and avoid mixing them as DateTime and DateTimeOffset are two different concepts.