### PR TITLE
Adds `BeAssignableTo` implementation for `Type` objects.

### DIFF
--- a/FluentAssertions.Core/Primitives/ReferenceTypeAssertions.cs
+++ b/FluentAssertions.Core/Primitives/ReferenceTypeAssertions.cs
@@ -151,13 +151,13 @@ namespace FluentAssertions.Primitives
         /// <typeparam name="T">The type to which the object should be assignable.</typeparam>
         /// <param name="because">The reason why the object should be assignable to the type.</param>
         /// <param name="reasonArgs">The parameters used when formatting the <paramref name="because"/>.</param>
-        /// <returns>An <see cref="AndConstraint{T}"/> which can be used to chain assertions.</returns>
+        /// <returns>An <see cref="AndWhichConstraint{TAssertions, T}"/> which can be used to chain assertions.</returns>
         public AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] reasonArgs)
         {
             Execute.Assertion
-                .ForCondition(typeof(T).IsAssignableFrom(Subject.GetType()))
+                .ForCondition(Subject is T)
                 .BecauseOf(because, reasonArgs)
-                .FailWith("Expected {context:" + Context + "} to be assignable to {0}{reason}, but {1} does not implement {0}",
+                .FailWith("Expected {context:" + Context + "} to be assignable to {0}{reason}, but {1} is not",
                     typeof(T),
                     Subject.GetType());
 

--- a/FluentAssertions.Core/Types/TypeAssertions.cs
+++ b/FluentAssertions.Core/Types/TypeAssertions.cs
@@ -64,6 +64,26 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Asserts than an instance of the subject type is assignable variable of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type to which instances of the type should be assignable.</typeparam>
+        /// <param name="because">The reason why instances of the type should be assignable to the type.</param>
+        /// <param name="reasonArgs">The parameters used when formatting the <paramref name="because"/>.</param>
+        /// <returns>An <see cref="AndConstraint{T}"/> which can be used to chain assertions.</returns>
+        public new AndConstraint<TypeAssertions> BeAssignableTo<T>(string because = "", params object[] reasonArgs)
+        {
+            Execute.Assertion
+                .ForCondition(typeof(T).IsAssignableFrom(Subject))
+                .BecauseOf(because, reasonArgs)
+                .FailWith(
+                    "Expected {context:" + Context + "} {0} to be assignable to {1}{reason}, but it is not",
+                    Subject,
+                    typeof(T));
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
         /// Creates an error message in case the specified <paramref name="actual"/> type differs from the 
         /// <paramref name="expected"/> type.
         /// </summary>

--- a/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
+++ b/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
@@ -2521,7 +2521,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>()
-                .WithMessage("Expected*assignable*string");
+                .WithMessage("Expected*assignable*string*");
         }
 
         #endregion

--- a/FluentAssertions.Shared.Specs/ObjectAssertionSpecs.cs
+++ b/FluentAssertions.Shared.Specs/ObjectAssertionSpecs.cs
@@ -375,36 +375,63 @@ namespace FluentAssertions.Specs
         #region BeAssignableTo
 
         [TestMethod]
-        public void Should_succeed_when_asserting_object_assignable_to_for_same_type()
+        public void When_asserting_an_object_is_assignable_its_own_type_it_should_succeed()
         {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
             var someObject = new DummyImplementingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
             someObject.Should().BeAssignableTo<DummyImplementingClass>();
         }
 
         [TestMethod]
-        public void Should_succeed_when_asserting_object_assignable_to_base_type()
+        public void When_asserting_an_object_is_assignable_to_its_base_type_it_should_succeed()
         {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
             var someObject = new DummyImplementingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
             someObject.Should().BeAssignableTo<DummyBaseClass>();
         }
 
         [TestMethod]
-        public void Should_succeed_when_asserting_object_assignable_to_implemented_interface_type()
+        public void When_asserting_an_object_is_assignable_to_an_implemented_interface_type_it_should_succeed()
         {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
             var someObject = new DummyImplementingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
             someObject.Should().BeAssignableTo<IDisposable>();
         }
 
         [TestMethod]
-        public void Should_fail_with_descriptive_message_when_asserting_object_assignable_to_not_implemented_type()
+        public void When_asserting_an_object_is_assignable_to_an_unrelated_type_it_should_fail_with_a_descriptive_message()
         {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
             var someObject = new DummyImplementingClass();
 
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
             someObject.Invoking(
                 x => x.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message"))
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage(string.Format(
-                    "Expected object to be assignable to {1} because we want to test the failure message, but {0} does not implement {1}",
+                    "Expected object to be assignable to {1} because we want to test the failure message, but {0} is not",
                     typeof(DummyImplementingClass), typeof(DateTime)));
         }
 

--- a/FluentAssertions.Shared.Specs/TypeAssertionSpecs.cs
+++ b/FluentAssertions.Shared.Specs/TypeAssertionSpecs.cs
@@ -363,6 +363,56 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region BeAssignableTo
+
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_its_own_type_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            typeof(DummyImplementingClass).Should().BeAssignableTo<DummyImplementingClass>();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_to_its_base_type_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            typeof(DummyImplementingClass).Should().BeAssignableTo<DummyBaseClass>();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_to_an_implemented_interface_type_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            typeof(DummyImplementingClass).Should().BeAssignableTo<IDisposable>();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_to_an_unrelated_type_it_should_fail_with_a_descriptive_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Type someType = typeof(DummyImplementingClass);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            someType.Invoking(
+                x => x.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message"))
+                .ShouldThrow<AssertFailedException>()
+                .WithMessage(string.Format(
+                    "Expected type {0} to be assignable to {1} because we want to test the failure message, but it is not",
+                    typeof(DummyImplementingClass), typeof(DateTime)));
+        }
+
+        #endregion
+
         #region BeDecoratedWith
 
         [TestMethod]


### PR DESCRIPTION
In the absence of this new hiding definition, FA would try to assert the Type, `Type`, was assignable to the type.  An assertion having no real value.

This also updates the formatting on the specs of the hidden method.

This also corrects a slight inaccuracy in the failure message of the hidden method.