### PR TITLE
New extension methods to make filtering of `Type`s functionality more accessible

### DIFF
--- a/FluentAssertions.Core/Core.csproj
+++ b/FluentAssertions.Core/Core.csproj
@@ -206,6 +206,7 @@
     <Compile Include="Specialized\ExceptionAssertions.cs" />
     <Compile Include="Specialized\IExtractExceptions.cs" />
     <Compile Include="TimeSpanConversionExtensions.cs" />
+    <Compile Include="TypeEnumerableExtensions.cs" />
     <Compile Include="TypeExtensions.cs" />
     <Compile Include="Types\AllTypes.cs" />
     <Compile Include="Types\MethodInfoAssertions.cs" />

--- a/FluentAssertions.Core/TypeEnumerableExtensions.cs
+++ b/FluentAssertions.Core/TypeEnumerableExtensions.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+using FluentAssertions.Types;
+
+namespace FluentAssertions
+{
+    /// <summary>
+    /// Extension methods for filtering a collection of types.
+    /// </summary>
+    public static class TypeEnumerableExtensions
+    {
+        /// <summary>
+        /// Filters to only include types decorated with a particular attribute.
+        /// </summary>
+        public static IEnumerable<Type> ThatAreDecoratedWith<TAttribute>(this IEnumerable<Type> types)
+        {
+            return new TypeSelector(types).ThatAreDecoratedWith<TAttribute>();
+        }
+
+        /// <summary>
+        /// Filters to only include types where the namespace of type is exactly <paramref name="namespace"/>.
+        /// </summary>
+        public static IEnumerable<Type> ThatAreInNamespace(this IEnumerable<Type> types, string @namespace)
+        {
+            return new TypeSelector(types).ThatAreInNamespace(@namespace);
+        }
+
+        /// <summary>
+        /// Filters to only include types where the namespace of type is starts with <paramref name="namespace"/>.
+        /// </summary>
+        public static IEnumerable<Type> ThatAreUnderNamespace(this IEnumerable<Type> types, string @namespace)
+        {
+            return new TypeSelector(types).ThatAreUnderNamespace(@namespace);
+        }
+
+        /// <summary>
+        /// Filters to only include types that subclass the specified type, but NOT the same type.
+        /// </summary>
+        public static IEnumerable<Type> ThatDeriveFrom<T>(this IEnumerable<Type> types)
+        {
+            return new TypeSelector(types).ThatDeriveFrom<T>();
+        }
+
+        /// <summary>
+        /// Determines whether a type implements an interface (but is not the interface itself).
+        /// </summary>
+        public static IEnumerable<Type> ThatImplement<T>(this IEnumerable<Type> types)
+        {
+            return new TypeSelector(types).ThatImplement<T>();
+        }
+    }
+}

--- a/FluentAssertions.Core/TypeExtensions.cs
+++ b/FluentAssertions.Core/TypeExtensions.cs
@@ -13,9 +13,6 @@ namespace FluentAssertions
     [DebuggerNonUserCode]
     public static class TypeExtensions
     {
-        private const BindingFlags PublicPropertiesFlag =
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
-
         /// <summary>
         /// Returns the types that are visible outside the specified <see cref="Assembly"/>.
         /// </summary>

--- a/FluentAssertions.Shared.Specs/TypeEnumerableExtensionsSpecs.cs
+++ b/FluentAssertions.Shared.Specs/TypeEnumerableExtensionsSpecs.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using FluentAssertions.Types;
+
+using Internal.Main.Test;
+using Internal.Other.Test;
+using Internal.Other.Test.Common;
+
+#if !OLD_MSTEST
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+
+namespace FluentAssertions.Specs
+{
+    [TestClass]
+    public class TypeEnumerableExtensionsSpecs
+    {
+        [TestMethod]
+        public void When_selecting_types_that_derive_from_a_specific_class_it_should_return_the_correct_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------            
+#if !WINRT && !WINDOWS_PHONE_APP
+            Assembly assembly = typeof(ClassDerivedFromSomeBaseClass).Assembly;
+#else
+            Assembly assembly = typeof(ClassDerivedFromSomeBaseClass).GetTypeInfo().Assembly;
+#endif
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = assembly.GetTypes().ThatDeriveFrom<SomeBaseClass>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should()
+                .HaveCount(1)
+                .And.Contain(typeof(ClassDerivedFromSomeBaseClass));
+        }
+
+        [TestMethod]
+        public void When_selecting_types_that_derive_from_a_specific_generic_class_it_should_return_the_correct_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+#if !WINRT && !WINDOWS_PHONE_APP
+            Assembly assembly = typeof(ClassDerivedFromSomeGenericBaseClass).Assembly;
+#else
+            Assembly assembly = typeof(ClassDerivedFromSomeGenericBaseClass).GetTypeInfo().Assembly;
+#endif
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            TypeSelector types = assembly.GetTypes().ThatDeriveFrom<SomeGenericBaseClass<int>>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.ToArray().Should()
+                .HaveCount(1)
+                .And.Contain(typeof(ClassDerivedFromSomeGenericBaseClass));
+        }
+
+        [TestMethod]
+        public void When_selecting_types_that_implement_a_specific_interface_it_should_return_the_correct_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+#if !WINRT && !WINDOWS_PHONE_APP
+            Assembly assembly = typeof(ClassImplementingSomeInterface).Assembly;
+#else
+            Assembly assembly = typeof(ClassImplementingSomeInterface).GetTypeInfo().Assembly;
+#endif
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = assembly.GetTypes().ThatImplement<ISomeInterface>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should()
+                .HaveCount(2)
+                .And.Contain(typeof(ClassImplementingSomeInterface))
+                .And.Contain(typeof(ClassWithSomeAttributeThatImplementsSomeInterface));
+        }
+
+        [TestMethod]
+        public void When_selecting_types_that_are_decorated_with_a_specific_attribute_it_should_return_the_correct_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+#if !WINRT && !WINDOWS_PHONE_APP
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
+#else
+            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+#endif
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = assembly.GetTypes().ThatAreDecoratedWith<SomeAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should()
+                .HaveCount(2)
+                .And.Contain(typeof(ClassWithSomeAttribute))
+                .And.Contain(typeof(ClassWithSomeAttributeThatImplementsSomeInterface));
+        }
+
+        [TestMethod]
+        public void When_selecting_types_from_specific_namespace_it_should_return_the_correct_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+#if !WINRT && !WINDOWS_PHONE_APP
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
+#else
+            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+#endif
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = assembly.GetTypes().ThatAreInNamespace("Internal.Other.Test");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should()
+                .HaveCount(1)
+                .And.Contain(typeof(SomeOtherClass));
+        }
+
+        [TestMethod]
+        public void When_selecting_types_from_specific_namespace_or_sub_namespaces_it_should_return_the_correct_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+#if !WINRT && !WINDOWS_PHONE_APP
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
+#else
+            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+#endif
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = assembly.GetTypes().ThatAreUnderNamespace("Internal.Other.Test");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should()
+                .HaveCount(2)
+                .And.Contain(typeof(SomeOtherClass))
+                .And.Contain(typeof(SomeCommonClass));
+        }
+
+        [TestMethod]
+        public void When_combining_type_selection_filters_it_should_return_the_correct_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+#if !WINRT && !WINDOWS_PHONE_APP
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
+#else
+            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+#endif
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = assembly.GetTypes()
+                .ThatAreDecoratedWith<SomeAttribute>()
+                .ThatImplement<ISomeInterface>()
+                .ThatAreInNamespace("Internal.Main.Test");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should()
+                .HaveCount(1)
+                .And.Contain(typeof(ClassWithSomeAttributeThatImplementsSomeInterface));
+        }
+    }
+}


### PR DESCRIPTION
This is done on the premise that these methods are rather useful; but, hard to find.

These extension methods are still on a fairly specialized type so they  should not cause much of a pollution problem.  Even then these might be fairly common things to want to do on that type so I still think it would not be pollution.