### PR TITLE
Fixes duplicate failure messages in ShouldBeEquivalentTo

### DIFF
--- a/FluentAssertions.Core/Execution/AssertionScope.cs
+++ b/FluentAssertions.Core/Execution/AssertionScope.cs
@@ -40,7 +40,7 @@ namespace FluentAssertions.Execution
         /// Starts an unnamed scope within which multiple assertions can be executed and which will not throw until the scope is disposed.
         /// </summary>
         public AssertionScope()
-            : this(new CollectingAssertionStrategy((current != null) ? current.assertionStrategy : null))
+            : this(new CollectingAssertionStrategy())
         {
             parent = current;
             current = this;

--- a/FluentAssertions.Core/Execution/CollectingAssertionStrategy.cs
+++ b/FluentAssertions.Core/Execution/CollectingAssertionStrategy.cs
@@ -11,14 +11,6 @@ namespace FluentAssertions.Execution
     {
         private readonly List<string> failureMessages = new List<string>();
 
-        public CollectingAssertionStrategy(IAssertionStrategy parent)
-        {
-            if (parent != null)
-            {
-                failureMessages.AddRange(parent.FailureMessages);
-            }
-        }
-
         /// <summary>
         /// Returns the messages for the assertion failures that happened until now.
         /// </summary>

--- a/FluentAssertions.Shared.Specs/AssertionScopeSpecs.cs
+++ b/FluentAssertions.Shared.Specs/AssertionScopeSpecs.cs
@@ -155,7 +155,7 @@ namespace FluentAssertions.Specs
             {
                 int matches = new Regex(".*Failure.*").Matches(exception.Message).Count;
 
-                Assert.AreEqual(6, matches);
+                Assert.AreEqual(4, matches);
             }
         }
 

--- a/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
@@ -272,6 +272,42 @@ namespace FluentAssertions.Specs
                 .WithMessage("Subject has member Value that the other object does not have.*");
         }
 
+        [TestMethod]
+        public void
+            When_asserting_equivalence_of_objects_including_enumerables_it_should_print_the_failure_message_only_once()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var record = new
+            {
+                Member1 = "",
+                Member2 = new[] {"", ""},
+            };
+            var record2 = new
+            {
+                Member1 = "different",
+                Member2 = new[] {"", ""},
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => record.ShouldBeEquivalentTo(record2);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(@"Expected member Member1 to be 
+
+""different"" with a length of 9, but 
+
+"""" has a length of 0.
+
+
+With configuration:*");
+        }
+
         #endregion
 
         #region Selection Rules


### PR DESCRIPTION
Corrects an issue wherein true duplicates of failure messages were being reported to users by `ShouldBeEquivalentTo` when the graph contained an Enumerable.

By 'true duplicates', I mean multiple reports of the same failure pertaining to the same member produced by a single check.  This is distinct from the previously removed "duplicates" where it was a distinct failure that produced the same failure message.
___

I found the fix a little surprising.  I did not trace history far enough to see why the code was added in the first place.  Since no tests broke by its removal I am thinking it is probably okay.  Based on how `AssertionScope.Dispose` is implemented I do not see how this removal would be an issue.

This does change the return from `Discard`, but that is what is fixing this bug for Collections (and Exceptions, untested).  I would be surprised if end-users are using `Discard` and depending on the return but if they are than this would be a breaking change.

I did trace history on the 6 vs 4 vs 1 in `AssertionScopeSpecs`.  I think going from 1 to 6 was just an oversight when deduplication was removed for #151.