### PR TITLE
134 central config

### DIFF
--- a/FluentAssertions.Core/AssertionOptions.cs
+++ b/FluentAssertions.Core/AssertionOptions.cs
@@ -1,6 +1,8 @@
 ﻿#region
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions.Equivalency;
 
 #endregion
@@ -13,6 +15,27 @@ namespace FluentAssertions
     public static class AssertionOptions
     {
         private static EquivalencyAssertionOptions defaults = new EquivalencyAssertionOptions();
+
+        static AssertionOptions()
+        {
+            EquivalencySteps = new EquivalencyStepCollection(GetDefaultSteps());
+        }
+
+        private static IEnumerable<IEquivalencyStep> GetDefaultSteps()
+        {
+            yield return new TryConversionEquivalencyStep();
+            yield return new ReferenceEqualityEquivalencyStep();
+            yield return new RunAllUserStepsEquivalencyStep();
+            yield return new GenericDictionaryEquivalencyStep();
+            yield return new DictionaryEquivalencyStep();
+            yield return new GenericEnumerableEquivalencyStep();
+            yield return new EnumerableEquivalencyStep();
+            yield return new StringEqualityEquivalencyStep();
+            yield return new SystemTypeEquivalencyStep();
+            yield return new EnumEqualityStep();
+            yield return new StructuralEqualityEquivalencyStep();
+            yield return new SimpleEqualityEquivalencyStep();
+        }
 
         internal static EquivalencyAssertionOptions<T> CloneDefaults<T>()
         {
@@ -30,5 +53,11 @@ namespace FluentAssertions
         {
             defaults = defaultsConfigurer(defaults);
         }
+
+        /// <summary>
+        /// Represents a mutable collection of steps that are executed while asserting a (collection of) object(s) 
+        /// is structurally equivalent to another (collection of) object(s).
+        /// </summary>
+        public static EquivalencyStepCollection EquivalencySteps { get; private set; }
     }
 }

--- a/FluentAssertions.Core/AssertionOptions.cs
+++ b/FluentAssertions.Core/AssertionOptions.cs
@@ -18,23 +18,7 @@ namespace FluentAssertions
 
         static AssertionOptions()
         {
-            EquivalencySteps = new EquivalencyStepCollection(GetDefaultSteps());
-        }
-
-        private static IEnumerable<IEquivalencyStep> GetDefaultSteps()
-        {
-            yield return new TryConversionEquivalencyStep();
-            yield return new ReferenceEqualityEquivalencyStep();
-            yield return new RunAllUserStepsEquivalencyStep();
-            yield return new GenericDictionaryEquivalencyStep();
-            yield return new DictionaryEquivalencyStep();
-            yield return new GenericEnumerableEquivalencyStep();
-            yield return new EnumerableEquivalencyStep();
-            yield return new StringEqualityEquivalencyStep();
-            yield return new SystemTypeEquivalencyStep();
-            yield return new EnumEqualityStep();
-            yield return new StructuralEqualityEquivalencyStep();
-            yield return new SimpleEqualityEquivalencyStep();
+            EquivalencySteps = new EquivalencyStepCollection();
         }
 
         internal static EquivalencyAssertionOptions<T> CloneDefaults<T>()

--- a/FluentAssertions.Core/AssertionOptions.cs
+++ b/FluentAssertions.Core/AssertionOptions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 
 #endregion
@@ -25,6 +26,16 @@ namespace FluentAssertions
         {
             return new EquivalencyAssertionOptions<T>(defaults);
         }
+
+        /// <summary>
+        /// Defines a predicate with which the <see cref="EquivalencyValidator"/> determines if it should process 
+        /// an object's properties or not. 
+        /// </summary>
+        /// <returns>
+        /// Returns <c>true</c> if the object should be treated as a value type and its <see cref="object.Equals(object)"/>
+        /// must be used during a structural equivalency check.
+        /// </returns>
+        public static Func<Type, bool> IsValueType = type => (type.Namespace == typeof (int).Namespace);
 
         /// <summary>
         /// Allows configuring the defaults used during a structural equivalency assertion.

--- a/FluentAssertions.Core/Collections/CollectionAssertions.cs
+++ b/FluentAssertions.Core/Collections/CollectionAssertions.cs
@@ -575,7 +575,7 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Expects the current collection to contain the specified elements in the exact same order. Elements are compared
+        /// Expects the current collection to contain the specified elements in the exact same order, not necessarily consecutive.
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
         /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
@@ -585,9 +585,11 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Expects the current collection to contain the specified elements in the exact same order. Elements are compared
-        /// using their <see cref="object.Equals(object)" /> implementation.
+        /// Expects the current collection to contain the specified elements in the exact same order, not necessarily consecutive.
         /// </summary>
+        /// <remarks>
+        /// Elements are compared using their <see cref="object.Equals(object)" /> implementation. 
+        /// </remarks>
         /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
@@ -1154,7 +1156,7 @@ namespace FluentAssertions.Collections
         {
             object[] collection = subject.ToArray();
             int index = Array.IndexOf(collection, succesor);
-            return (index > 0) ? collection[0] : null;
+            return (index > 0) ? collection[index - 1] : null;
         }
         
         /// <summary>

--- a/FluentAssertions.Core/Common/TypeExtensions.cs
+++ b/FluentAssertions.Core/Common/TypeExtensions.cs
@@ -90,14 +90,12 @@ namespace FluentAssertions.Common
 
         public static bool IsComplexType(this Type type)
         {
-            return HasProperties(type) && (type.Namespace != typeof (int).Namespace);
+            return HasProperties(type) && !AssertionOptions.IsValueType(type);
         }
 
         private static bool HasProperties(Type type)
         {
-            return type
-                .GetProperties(PublicMembersFlag)
-                .Any();
+            return type.GetProperties(PublicMembersFlag).Any();
         }
 
         /// <summary>

--- a/FluentAssertions.Core/Core.csproj
+++ b/FluentAssertions.Core/Core.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Equivalency\PropertySelectedMemberInfo.cs" />
     <Compile Include="Equivalency\MemberInfoSelectedMemberInfo.cs" />
     <Compile Include="Equivalency\SelectedMemberInfo.cs" />
+    <Compile Include="Equivalency\RunAllUserStepsEquivalencyStep.cs" />
     <Compile Include="Equivalency\ShouldAllBeEquivalentToHelper.cs" />
     <Compile Include="Equivalency\StringEqualityEquivalencyStep.cs" />
     <Compile Include="Equivalency\SystemTypeEqualityEquivalencyStep.cs" />

--- a/FluentAssertions.Core/Core.csproj
+++ b/FluentAssertions.Core/Core.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Common\PlatformAdapter.cs" />
     <Compile Include="Common\ProbingAdapterResolver.cs" />
     <Compile Include="Equivalency\AllPublicFieldsSelectionRule.cs" />
+    <Compile Include="EquivalencyStepCollection.cs" />
     <Compile Include="Equivalency\AssertionContext.cs" />
     <Compile Include="Equivalency\AssertionRuleEquivalencyStep.cs" />
     <Compile Include="Equivalency\AssertionRuleEquivalencyStepAdaptor.cs" />

--- a/FluentAssertions.Core/Core.csproj
+++ b/FluentAssertions.Core/Core.csproj
@@ -90,7 +90,7 @@
     <Compile Include="Equivalency\RunAllUserStepsEquivalencyStep.cs" />
     <Compile Include="Equivalency\ShouldAllBeEquivalentToHelper.cs" />
     <Compile Include="Equivalency\StringEqualityEquivalencyStep.cs" />
-    <Compile Include="Equivalency\SystemTypeEqualityEquivalencyStep.cs" />
+    <Compile Include="Equivalency\ValueTypeEquivalencyStep.cs" />
     <Compile Include="Execution\Continuation.cs" />
     <Compile Include="Execution\MessageBuilder.cs" />
     <Compile Include="Execution\ContinuationOfGiven.cs" />

--- a/FluentAssertions.Core/Equivalency/AssertionRuleEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/AssertionRuleEquivalencyStep.cs
@@ -6,7 +6,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency
 {
-    internal class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
+    public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
     {
         private readonly Expression<Func<ISubjectInfo, bool>> canHandle;
 

--- a/FluentAssertions.Core/Equivalency/DictionaryEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/DictionaryEquivalencyStep.cs
@@ -5,7 +5,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency
 {
-    internal class DictionaryEquivalencyStep : IEquivalencyStep
+    public class DictionaryEquivalencyStep : IEquivalencyStep
     {
         /// <summary>
         /// Gets a value indicating whether this step can handle the current subject and/or expectation.

--- a/FluentAssertions.Core/Equivalency/EnumEqualityStep.cs
+++ b/FluentAssertions.Core/Equivalency/EnumEqualityStep.cs
@@ -1,10 +1,13 @@
+#region
+
 using System;
 using System.Globalization;
-using System.Linq;
+
+#endregion
 
 namespace FluentAssertions.Equivalency
 {
-    internal class EnumEqualityStep : IEquivalencyStep
+    public class EnumEqualityStep : IEquivalencyStep
     {
         /// <summary>
         /// Gets a value indicating whether this step can handle the current subject and/or expectation.
@@ -26,7 +29,8 @@ namespace FluentAssertions.Equivalency
         /// <remarks>
         /// May throw when preconditions are not met or if it detects mismatching data.
         /// </remarks>
-        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent,
+            IEquivalencyAssertionOptions config)
         {
             switch (config.EnumEquivalencyHandling)
             {
@@ -34,10 +38,13 @@ namespace FluentAssertions.Equivalency
                     CompareByValue(context);
                     break;
                 case EnumEquivalencyHandling.ByName:
-                    context.Subject.ToString().Should().Be(context.Expectation.ToString(), context.Reason, context.ReasonArgs);
+                    context.Subject.ToString()
+                        .Should()
+                        .Be(context.Expectation.ToString(), context.Reason, context.ReasonArgs);
                     break;
                 default:
-                    throw new InvalidOperationException(string.Format("Don't know how to handle {0}", config.EnumEquivalencyHandling));
+                    throw new InvalidOperationException(string.Format("Don't know how to handle {0}",
+                        config.EnumEquivalencyHandling));
             }
 
             return true;
@@ -49,8 +56,9 @@ namespace FluentAssertions.Equivalency
             var subjectUnderlyingValue = Convert.ChangeType(context.Subject, subjectType, CultureInfo.InvariantCulture);
 
             var expectationType = Enum.GetUnderlyingType(context.Expectation.GetType());
-            var expectationUnderlyingValue = Convert.ChangeType(context.Expectation, expectationType, CultureInfo.InvariantCulture);
-            
+            var expectationUnderlyingValue = Convert.ChangeType(context.Expectation, expectationType,
+                CultureInfo.InvariantCulture);
+
             subjectUnderlyingValue.Should().Be(expectationUnderlyingValue, context.Reason, context.ReasonArgs);
         }
     }

--- a/FluentAssertions.Core/Equivalency/EnumerableEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/EnumerableEquivalencyStep.cs
@@ -7,7 +7,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency
 {
-    internal class EnumerableEquivalencyStep : IEquivalencyStep
+    public class EnumerableEquivalencyStep : IEquivalencyStep
     {
         /// <summary>
         /// Gets a value indicating whether this step can handle the verificationScope subject and/or expectation.

--- a/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptionsBase.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptionsBase.cs
@@ -44,6 +44,8 @@ namespace FluentAssertions.Equivalency
 
         private bool includeFields;
 
+        private List<Type> valueTypes = new List<Type>(); 
+
         /// <summary>
         /// A value indicating whether the default selection rules need to be prepended or not.
         /// </summary>
@@ -188,6 +190,14 @@ namespace FluentAssertions.Equivalency
         bool IEquivalencyAssertionOptions.IncludeFields
         {
             get { return includeFields; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the <paramref name="type"/> should be treated as having value semantics.
+        /// </summary>
+        bool IEquivalencyAssertionOptions.IsValueType(Type type)
+        {
+            return valueTypes.Contains(type) || AssertionOptions.IsValueType(type);
         }
 
         /// <summary>
@@ -514,6 +524,16 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingEnumsByValue()
         {
             enumEquivalencyHandling = EnumEquivalencyHandling.ByValue;
+            return (TSelf) this;
+        }
+
+        /// <summary>
+        /// Marks the <typeparamref name="T"/> as a value type which must be compared using its 
+        /// <see cref="object.Equals(object)"/> method.
+        /// </summary>
+        public TSelf ComparingByValue<T>()
+        {
+            valueTypes.Add(typeof(T));
             return (TSelf) this;
         }
 

--- a/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptionsBase.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptionsBase.cs
@@ -54,7 +54,7 @@ namespace FluentAssertions.Equivalency
         internal EquivalencyAssertionOptionsBase()
         {
             AddMatchingRule(new MustMatchByNameRule());
-            
+
             orderingRules.Add(new ByteArrayOrderingRule());
         }
 
@@ -302,6 +302,16 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
+        /// Tries to match the properties of the subject with equally named properties on the expectation. Ignores those 
+        /// properties that don't exist on the expectation and previously registered matching rules.
+        /// </summary>
+        [Obsolete("This method will be removed in a future version.  Use `ExcludingMissingMembers()` instead.")]
+        public TSelf ExcludingMissingProperties()
+        {
+            return ExcludingMissingMembers();
+        }
+
+        /// <summary>
         /// Tries to match the members of the subject with equally named members on the expectation. Ignores those 
         /// members that don't exist on the expectation and previously registered matching rules.
         /// </summary>
@@ -313,13 +323,13 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Tries to match the properties of the subject with equally named properties on the expectation. Ignores those 
-        /// properties that don't exist on the expectation and previously registered matching rules.
+        /// Requires the expectation to have properties which are equally named to properties on the subject.
         /// </summary>
-        [Obsolete("This method will be removed in a future version.  Use `ExcludingMissingMembers()` instead.")]
-        public TSelf ExcludingMissingProperties()
+        /// <returns></returns>
+        [Obsolete("This method will be removed in a future version.  Use `ThrowOnMissingMembers()` instead.")]
+        public TSelf ThrowingOnMissingProperties()
         {
-            return ExcludingMissingMembers();
+            return ThrowingOnMissingMembers();
         }
 
         /// <summary>
@@ -331,16 +341,6 @@ namespace FluentAssertions.Equivalency
             ClearMatchingRules();
             matchingRules.Add(new MustMatchByNameRule());
             return (TSelf)this;
-        }
-
-        /// <summary>
-        /// Requires the expectation to have properties which are equally named to properties on the subject.
-        /// </summary>
-        /// <returns></returns>
-        [Obsolete("This method will be removed in a future version.  Use `ThrowOnMissingMembers()` instead.")]
-        public TSelf ThrowingOnMissingProperties()
-        {
-            return ThrowingOnMissingMembers();
         }
 
         /// <param name="action">

--- a/FluentAssertions.Core/Equivalency/EquivalencyValidator.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyValidator.cs
@@ -50,17 +50,9 @@ namespace FluentAssertions.Equivalency
 
                 if (!objectTracker.IsCyclicReference(new ObjectReference(context.Subject, context.SelectedMemberPath)))
                 {
-                    bool wasHandled = false;
-
-                    IList<IEquivalencyStep> steps = GetSteps().ToList();
-                    foreach (var strategy in steps.Where(s => s.CanHandle(context, config)))
-                    {
-                        if (strategy.Handle(context, this, config))
-                        {
-                            wasHandled = true;
-                            break;
-                        }
-                    }
+                    bool wasHandled = GetSteps().ToList()
+                        .Where(s => s.CanHandle(context, config))
+                        .Any(step => step.Handle(context, this, config));
 
                     if (!wasHandled)
                     {
@@ -76,12 +68,7 @@ namespace FluentAssertions.Equivalency
         {
             yield return new TryConversionEquivalencyStep();
             yield return new ReferenceEqualityEquivalencyStep();
-
-            foreach (var equivalencyStep in config.UserEquivalencySteps)
-            {
-                yield return equivalencyStep;
-            }
-
+            yield return new RunAllUserStepsEquivalencyStep();
             yield return new GenericDictionaryEquivalencyStep();
             yield return new DictionaryEquivalencyStep();
             yield return new GenericEnumerableEquivalencyStep();

--- a/FluentAssertions.Core/Equivalency/EquivalencyValidator.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyValidator.cs
@@ -50,7 +50,7 @@ namespace FluentAssertions.Equivalency
 
                 if (!objectTracker.IsCyclicReference(new ObjectReference(context.Subject, context.SelectedMemberPath)))
                 {
-                    bool wasHandled = GetSteps().ToList()
+                    bool wasHandled = AssertionOptions.EquivalencySteps
                         .Where(s => s.CanHandle(context, config))
                         .Any(step => step.Handle(context, this, config));
 
@@ -62,22 +62,6 @@ namespace FluentAssertions.Equivalency
                     }
                 }
             }
-        }
-
-        private IEnumerable<IEquivalencyStep> GetSteps()
-        {
-            yield return new TryConversionEquivalencyStep();
-            yield return new ReferenceEqualityEquivalencyStep();
-            yield return new RunAllUserStepsEquivalencyStep();
-            yield return new GenericDictionaryEquivalencyStep();
-            yield return new DictionaryEquivalencyStep();
-            yield return new GenericEnumerableEquivalencyStep();
-            yield return new EnumerableEquivalencyStep();
-            yield return new StringEqualityEquivalencyStep();
-            yield return new SystemTypeEquivalencyStep();
-            yield return new EnumEqualityStep();
-            yield return new StructuralEqualityEquivalencyStep();
-            yield return new SimpleEqualityEquivalencyStep();
         }
 
         private bool ContinueRecursion(string memberAccessPath)

--- a/FluentAssertions.Core/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -12,7 +12,7 @@ namespace FluentAssertions.Equivalency
     /// I think (but did not try) this would have been easier using 'dynamic' but that is
     /// precluded by some of the PCL targets.
     /// </remarks>
-    internal class GenericDictionaryEquivalencyStep : IEquivalencyStep
+    public class GenericDictionaryEquivalencyStep : IEquivalencyStep
     {
         public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
         {

--- a/FluentAssertions.Core/Equivalency/GenericEnumerableEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/GenericEnumerableEquivalencyStep.cs
@@ -8,7 +8,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency
 {
-    internal class GenericEnumerableEquivalencyStep : IEquivalencyStep
+    public class GenericEnumerableEquivalencyStep : IEquivalencyStep
     {
         /// <summary>
         /// Gets a value indicating whether this step can handle the verificationScope subject and/or expectation.

--- a/FluentAssertions.Core/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/FluentAssertions.Core/Equivalency/IEquivalencyAssertionOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace FluentAssertions.Equivalency
@@ -63,5 +64,10 @@ namespace FluentAssertions.Equivalency
         /// Gets a value indicating whether fields should be considered.
         /// </summary>
         bool IncludeFields { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the <paramref name="type"/> should be treated as having value semantics.
+        /// </summary>
+        bool IsValueType(Type type);
     }
 }

--- a/FluentAssertions.Core/Equivalency/ObjectReference.cs
+++ b/FluentAssertions.Core/Equivalency/ObjectReference.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Linq;
-
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency
@@ -28,10 +26,9 @@ namespace FluentAssertions.Equivalency
         /// <param name="obj">The <see cref="T:System.Object"/> to compare with the current <see cref="T:System.Object"/>. </param><filterpriority>2</filterpriority>
         public override bool Equals(object obj)
         {
-            var other = (ObjectReference)obj;
+            var other = (ObjectReference) obj;
 
             return ReferenceEquals(@object, other.@object) && IsParentOf(other);
-
         }
 
         private bool IsParentOf(ObjectReference other)
@@ -50,7 +47,7 @@ namespace FluentAssertions.Equivalency
         {
             unchecked
             {
-                return (@object.GetHashCode() * 397) ^ path.GetHashCode();
+                return (@object.GetHashCode()*397) ^ path.GetHashCode();
             }
         }
 
@@ -59,7 +56,7 @@ namespace FluentAssertions.Equivalency
             return string.Format("{{\"{0}\", {1}}}", path, @object);
         }
 
-        public bool IsReference
+        public bool IsComplexType
         {
             get { return !ReferenceEquals(@object, null) && @object.GetType().IsComplexType(); }
         }

--- a/FluentAssertions.Core/Equivalency/ObjectTracker.cs
+++ b/FluentAssertions.Core/Equivalency/ObjectTracker.cs
@@ -35,7 +35,7 @@ namespace FluentAssertions.Equivalency
         {
             bool isCyclic = false;
 
-            if (reference.IsReference)
+            if (reference.IsComplexType)
             {
                 if (references.Contains(reference))
                 {

--- a/FluentAssertions.Core/Equivalency/ReferenceEqualityEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/ReferenceEqualityEquivalencyStep.cs
@@ -1,6 +1,6 @@
 ﻿namespace FluentAssertions.Equivalency
 {
-    internal class ReferenceEqualityEquivalencyStep : IEquivalencyStep
+    public class ReferenceEqualityEquivalencyStep : IEquivalencyStep
     {
         /// <summary>
         /// Gets a value indicating whether this step can handle the current subject and/or expectation.

--- a/FluentAssertions.Core/Equivalency/RunAllUserStepsEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/RunAllUserStepsEquivalencyStep.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+
+namespace FluentAssertions.Equivalency
+{
+    /// <summary>
+    /// Represents a composite equivalency step that passes the execution to all user-supplied steps that can handle the 
+    /// current context.
+    /// </summary>
+    public class RunAllUserStepsEquivalencyStep : IEquivalencyStep
+    {
+        public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            return config.UserEquivalencySteps.Any(s => s.CanHandle(context, config));
+        }
+
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent,
+            IEquivalencyAssertionOptions config)
+        {
+            return config.UserEquivalencySteps
+                .Where(s => s.CanHandle(context, config))
+                .Any(step => step.Handle(context, parent, config));
+        }
+    }
+}

--- a/FluentAssertions.Core/Equivalency/ShouldAllBeEquivalentToHelper.cs
+++ b/FluentAssertions.Core/Equivalency/ShouldAllBeEquivalentToHelper.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 
 namespace FluentAssertions.Equivalency
 {
+    // SMELL static class with lots of undocumented decorators
     public static class ShouldAllBeEquivalentToHelper
     {
         /// <summary>
@@ -26,7 +27,7 @@ namespace FluentAssertions.Equivalency
             return optionsToConfigure;
         }
 
-        internal static void ConfigureAssertionRules<TActual>(
+        private static void ConfigureAssertionRules<TActual>(
             EquivalencyAssertionOptions<TActual> actualOptions,
             IEquivalencyAssertionOptions subConfigOptions)
         {
@@ -37,7 +38,7 @@ namespace FluentAssertions.Equivalency
             }
         }
 
-        internal static void ConfigureSelectionRules<TActual>(
+        private static void ConfigureSelectionRules<TActual>(
             EquivalencyAssertionOptions<TActual> actualOptions,
             IEquivalencyAssertionOptions subConfigOptions)
         {
@@ -53,7 +54,7 @@ namespace FluentAssertions.Equivalency
             }
         }
 
-        internal static void ConfigureOrderingRules<TActual>(
+        private static void ConfigureOrderingRules<TActual>(
             EquivalencyAssertionOptions<TActual> actualOptions,
             IEquivalencyAssertionOptions subConfigOptions)
         {
@@ -64,7 +65,7 @@ namespace FluentAssertions.Equivalency
             }
         }
 
-        internal static void ConfigureMatchingRules<TActual>(
+        private static void ConfigureMatchingRules<TActual>(
             EquivalencyAssertionOptions<TActual> actualOptions,
             IEquivalencyAssertionOptions subConfigOptions)
         {

--- a/FluentAssertions.Core/Equivalency/SimpleEqualityEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/SimpleEqualityEquivalencyStep.cs
@@ -1,6 +1,6 @@
 namespace FluentAssertions.Equivalency
 {
-    internal class SimpleEqualityEquivalencyStep : IEquivalencyStep
+    public class SimpleEqualityEquivalencyStep : IEquivalencyStep
     {
         /// <summary>
         /// Gets a value indicating whether this step can handle the current subject and/or expectation.

--- a/FluentAssertions.Core/Equivalency/StringEqualityEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/StringEqualityEquivalencyStep.cs
@@ -5,7 +5,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency
 {
-    internal class StringEqualityEquivalencyStep : IEquivalencyStep
+    public class StringEqualityEquivalencyStep : IEquivalencyStep
     {
         /// <summary>
         /// Gets a value indicating whether this step can handle the current subject and/or expectation.

--- a/FluentAssertions.Core/Equivalency/StructuralEqualityEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/StructuralEqualityEquivalencyStep.cs
@@ -5,7 +5,7 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency
 {
-    internal class StructuralEqualityEquivalencyStep : IEquivalencyStep
+    public class StructuralEqualityEquivalencyStep : IEquivalencyStep
     {
         /// <summary>
         /// Gets a value indicating whether this step can handle the current subject and/or expectation.

--- a/FluentAssertions.Core/Equivalency/SystemTypeEqualityEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/SystemTypeEqualityEquivalencyStep.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace FluentAssertions.Equivalency
 {
-    internal class SystemTypeEquivalencyStep : IEquivalencyStep
+    public class SystemTypeEquivalencyStep : IEquivalencyStep
     {
         /// <summary>
         /// Gets a value indicating whether this step can handle the current subject and/or expectation.

--- a/FluentAssertions.Core/Equivalency/TryConversionEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/TryConversionEquivalencyStep.cs
@@ -5,7 +5,7 @@ using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency
 {
-    internal class TryConversionEquivalencyStep : IEquivalencyStep
+    public class TryConversionEquivalencyStep : IEquivalencyStep
     {
         /// <summary>
         /// Gets a value indicating whether this step can handle the current subject and/or expectation.

--- a/FluentAssertions.Core/Equivalency/ValueTypeEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/ValueTypeEquivalencyStep.cs
@@ -2,7 +2,10 @@ using System;
 
 namespace FluentAssertions.Equivalency
 {
-    public class SystemTypeEquivalencyStep : IEquivalencyStep
+    /// <summary>
+    /// Ensures that types that are marked as value types are treated as such.
+    /// </summary>
+    public class ValueTypeEquivalencyStep : IEquivalencyStep
     {
         /// <summary>
         /// Gets a value indicating whether this step can handle the current subject and/or expectation.
@@ -11,10 +14,11 @@ namespace FluentAssertions.Equivalency
         {
             Type type = config.GetSubjectType(context);
 
-            return (type != null) &&
-                   (type != typeof (object)) &&
-                   (type.Namespace == typeof (int).Namespace) &&
-                   (!type.IsArray);
+            return 
+                (type != null) && 
+                (type != typeof (object)) && 
+                config.IsValueType(type) && 
+                !type.IsArray;
         }
 
         /// <summary>

--- a/FluentAssertions.Core/EquivalencyStepCollection.cs
+++ b/FluentAssertions.Core/EquivalencyStepCollection.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using FluentAssertions.Equivalency;
+
+namespace FluentAssertions
+{
+    /// <summary>
+    /// Represents a mutable collection of equivalency steps that can be reordered and/or ammended with additional
+    /// custom equivalency steps. 
+    /// </summary>
+    public class EquivalencyStepCollection : IEnumerable<IEquivalencyStep>
+    {
+        private readonly List<IEquivalencyStep> steps = new List<IEquivalencyStep>();
+
+        public EquivalencyStepCollection(IEnumerable<IEquivalencyStep> defaultSteps)
+        {
+            steps.AddRange(defaultSteps);
+        }
+
+        public IEnumerator<IEquivalencyStep> GetEnumerator()
+        {
+            return steps.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/FluentAssertions.Core/EquivalencyStepCollection.cs
+++ b/FluentAssertions.Core/EquivalencyStepCollection.cs
@@ -1,20 +1,26 @@
-﻿using System.Collections;
+﻿#region
+
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions.Equivalency;
+
+#endregion
 
 namespace FluentAssertions
 {
     /// <summary>
-    /// Represents a mutable collection of equivalency steps that can be reordered and/or ammended with additional
+    /// Represents a mutable collection of equivalency steps that can be reordered and/or amended with additional
     /// custom equivalency steps. 
     /// </summary>
     public class EquivalencyStepCollection : IEnumerable<IEquivalencyStep>
     {
-        private readonly List<IEquivalencyStep> steps = new List<IEquivalencyStep>();
+        private List<IEquivalencyStep> steps;
 
-        public EquivalencyStepCollection(IEnumerable<IEquivalencyStep> defaultSteps)
+        public EquivalencyStepCollection()
         {
-            steps.AddRange(defaultSteps);
+            steps = GetDefaultSteps().ToList();
         }
 
         public IEnumerator<IEquivalencyStep> GetEnumerator()
@@ -25,6 +31,92 @@ namespace FluentAssertions
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
+        }
+
+        /// <summary>
+        /// Adds a new <see cref="IEquivalencyStep"/> after any of the built-in steps, with the exception of the final 
+        /// <see cref="SimpleEqualityEquivalencyStep"/>.
+        /// </summary>
+        public void Add<TStep>() where TStep : IEquivalencyStep, new()
+        {
+            InsertBefore<SimpleEqualityEquivalencyStep, TStep>();
+        }
+
+        /// <summary>
+        /// Adds a new <see cref="IEquivalencyStep"/> right after the specified <typeparamref name="TPredecessor"/>.
+        /// </summary>
+        public void AddAfter<TPredecessor, TStep>() where TStep : IEquivalencyStep, new()
+        {
+            int insertIndex = Math.Max(steps.Count - 1, 0);
+
+            IEquivalencyStep predecessor = steps.LastOrDefault(s => s is TPredecessor);
+            if (predecessor != null)
+            {
+                insertIndex = Math.Min(insertIndex, steps.LastIndexOf(predecessor) + 1);
+            }
+
+            steps.Insert(insertIndex, new TStep());
+        }
+
+        /// <summary>
+        /// Inserts a new <see cref="IEquivalencyStep"/> before any of the built-in steps. 
+        /// </summary>
+        public void Insert<TStep>() where TStep : IEquivalencyStep, new()
+        {
+            steps.Insert(0, new TStep());
+        }
+
+        /// <summary>
+        /// Inserts a new <see cref="IEquivalencyStep"/> just before the <typeparamref name="TSuccessor"/>.
+        /// </summary>
+        public void InsertBefore<TSuccessor, TStep>() where TStep : IEquivalencyStep, new()
+        {
+            int insertIndex = Math.Max(steps.Count - 1, 0);
+
+            IEquivalencyStep equalityStep = steps.LastOrDefault(s => s is TSuccessor);
+            if (equalityStep != null)
+            {
+                insertIndex = steps.LastIndexOf(equalityStep);
+            }
+
+            steps.Insert(insertIndex, new TStep());
+        }
+
+        /// <summary>
+        /// Removes all instances of the specified <typeparamref name="TStep"/> from the current step.
+        /// </summary>
+        public void Remove<TStep>() where TStep : IEquivalencyStep
+        {
+            steps.RemoveAll(s => s is TStep);
+        }
+
+        /// <summary>
+        /// Removes each and every built-in <see cref="IEquivalencyStep"/>.
+        /// </summary>
+        public void Clear()
+        {
+            steps.Clear();
+        }
+
+        public void Reset()
+        {
+            steps = GetDefaultSteps().ToList();
+        }
+
+        private static IEnumerable<IEquivalencyStep> GetDefaultSteps()
+        {
+            yield return new TryConversionEquivalencyStep();
+            yield return new ReferenceEqualityEquivalencyStep();
+            yield return new RunAllUserStepsEquivalencyStep();
+            yield return new GenericDictionaryEquivalencyStep();
+            yield return new DictionaryEquivalencyStep();
+            yield return new GenericEnumerableEquivalencyStep();
+            yield return new EnumerableEquivalencyStep();
+            yield return new StringEqualityEquivalencyStep();
+            yield return new SystemTypeEquivalencyStep();
+            yield return new EnumEqualityStep();
+            yield return new StructuralEqualityEquivalencyStep();
+            yield return new SimpleEqualityEquivalencyStep();
         }
     }
 }

--- a/FluentAssertions.Core/EquivalencyStepCollection.cs
+++ b/FluentAssertions.Core/EquivalencyStepCollection.cs
@@ -113,7 +113,7 @@ namespace FluentAssertions
             yield return new GenericEnumerableEquivalencyStep();
             yield return new EnumerableEquivalencyStep();
             yield return new StringEqualityEquivalencyStep();
-            yield return new SystemTypeEquivalencyStep();
+            yield return new ValueTypeEquivalencyStep();
             yield return new EnumEqualityStep();
             yield return new StructuralEqualityEquivalencyStep();
             yield return new SimpleEqualityEquivalencyStep();

--- a/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System;
 using System.Globalization;
 using System.Collections.Generic;
@@ -83,14 +84,14 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_equivilence_on_a_type_from_System_it_should_not_do_a_structural_comparision()
+        public void When_asserting_equivalence_on_a_value_type_from_system_it_should_not_do_a_structural_comparision()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
 
             // DateTime is used as an example because the current implemention
-            // would hit the recusion-depth limit if structural equivilence were attempted.
+            // would hit the recursion-depth limit if structural equivalence were attempted.
             DateTime date1 = DateTime.Parse("2011-01-01");
             DateTime date2 = DateTime.Parse("2011-01-01");
 
@@ -104,6 +105,36 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldNotThrow();
         }
+        
+#if !WINRT && !NETFX_CORE && !WINDOWS_PHONE_APP && !SILVERLIGHT
+        [TestMethod]
+        public void When_asserting_equivalence_on_a_reference_type_from_system_it_should_not_do_a_structural_comparision()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new
+            {
+                Address = IPAddress.Parse("1.2.3.4"), Word = "a"
+            };
+            
+            var expected = new
+            {
+                Address = IPAddress.Parse("1.2.3.4"), Word = "a"
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.ShouldBeEquivalentTo(expected, 
+                options => options.ComparingByValue<IPAddress>());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+#endif
 
         [TestMethod]
         public void When_asserting_equivilence_on_a_string_it_should_use_string_specific_failure_messages()

--- a/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
+++ b/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
@@ -2558,13 +2558,13 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act 
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => collection.Should().HaveElementPreceding("mick", "john", "because of some reason");
+            Action act = () => collection.Should().HaveElementPreceding("john", "cris", "because of some reason");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>()
-                .WithMessage("Expected*john*precede*mick*because*reason*found*cris*");
+                .WithMessage("Expected*cris*precede*john*because*reason*found*mick*");
         }
 
         [TestMethod]

--- a/FluentAssertions.sln.DotSettings
+++ b/FluentAssertions.sln.DotSettings
@@ -2,6 +2,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/IdentifierHighlightingEnabled/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StyleCop_002ESA1101/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=Safe_0020Cleanup/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="Safe Cleanup"&gt;&lt;CSArrangeThisQualifier&gt;True&lt;/CSArrangeThisQualifier&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;EmbraceInRegion&gt;False&lt;/EmbraceInRegion&gt;&lt;RegionName&gt;&lt;/RegionName&gt;&lt;/CSOptimizeUsings&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;/Profile&gt;</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>

--- a/FluentAssertions.sln.DotSettings
+++ b/FluentAssertions.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/IdentifierHighlightingEnabled/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StyleCop_002ESA1101/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">False</s:Boolean>

--- a/Shared/AssertionExtensions.cs
+++ b/Shared/AssertionExtensions.cs
@@ -488,8 +488,7 @@ namespace FluentAssertions
         /// irrespective of the type of those objects. Two properties are also equal if one type can be converted to another and the result is equal.
         /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable"/> and all
         /// items in the collection are structurally equal. 
-        /// Notice that actual behavior is determined by the <see cref="EquivalencyAssertionOptions.Default"/> instance of the 
-        /// <see cref="EquivalencyAssertionOptions"/> class.
+        /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
         /// <param name="because">
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the 
@@ -514,9 +513,10 @@ namespace FluentAssertions
         /// items in the collection are structurally equal. 
         /// </remarks>
         /// <param name="config">
-        /// A reference to the <see cref="EquivalencyAssertionOptions.Default"/> configuration object that can be used 
+        /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used 
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the 
-        /// <see cref="EquivalencyAssertionOptions"/> class.
+        /// <see cref="EquivalencyAssertionOptions{TSubject}"/> class. The global defaults are determined by the 
+        /// <see cref="AssertionOptions"/> class.
         /// </param>
         /// <param name="because">
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the 
@@ -543,12 +543,53 @@ namespace FluentAssertions
 #pragma warning restore 618
         }
 
+        /// <summary>
+        /// Asserts that a collection of objects is equivalent to another collection of objects. 
+        /// </summary>
+        /// <remarks>
+        /// Objects within the collections are equivalent when both object graphs have equally named properties with the same 
+        /// value, irrespective of the type of those objects. Two properties are also equal if one type can be converted to another 
+        /// and the result is equal. 
+        /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable"/> and all
+        /// items in the collection are structurally equal. 
+        /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
+        /// </remarks>
+        /// <param name="because">
+        /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the 
+        /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="reasonArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// </param>
         public static void ShouldAllBeEquivalentTo<T>(this IEnumerable<T> subject, IEnumerable expectation,
             string because = "", params object[] reasonArgs)
         {
             subject.ShouldBeEquivalentTo(expectation, because, reasonArgs);
         }
 
+        /// <summary>
+        /// Asserts that a collection of objects is equivalent to another collection of objects. 
+        /// </summary>
+        /// <remarks>
+        /// Objects within the collections are equivalent when both object graphs have equally named properties with the same 
+        /// value,  irrespective of the type of those objects. Two properties are also equal if one type can be converted to another 
+        /// and the result is equal. 
+        /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable"/> and all
+        /// items in the collection are structurally equal. 
+        /// </remarks>
+        /// <param name="config">
+        /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used 
+        /// to influence the way the object graphs are compared. You can also provide an alternative instance of the 
+        /// <see cref="EquivalencyAssertionOptions{TSubject}"/> class. The global defaults are determined by the 
+        /// <see cref="AssertionOptions"/> class.
+        /// </param>
+        /// <param name="because">
+        /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the 
+        /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="reasonArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// </param>
         public static void ShouldAllBeEquivalentTo<T>(this IEnumerable<T> subject, IEnumerable expectation,
             Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> config, string because = "",
             params object[] reasonArgs)


### PR DESCRIPTION
Introduced an API to change the rules for evaluating whether a type should be treated as having value semantics, either for a single structural equality comparison or globally.