### PR TITLE
Resolve FailWith overload resolution when only constant-string is passed

### DIFF
--- a/FluentAssertions.Core/Execution/GivenSelector.cs
+++ b/FluentAssertions.Core/Execution/GivenSelector.cs
@@ -113,5 +113,24 @@ namespace FluentAssertions.Execution
 
             return new ContinuationOfGiven<T>(this, parentScope);
         }
+
+        /// <summary>
+        /// Sets the failure message when the assertion is not met, or completes the failure message set to a 
+        /// prior call to to <see cref="WithExpectation"/>.
+        /// </summary>
+        /// <remarks>
+        /// If an expectation was set through a prior call to <see cref="WithExpectation"/>, then the failure message is appended to that
+        /// expectation. 
+        /// </remarks>
+        /// <param name="message">The format string that represents the failure message.</param>
+        public ContinuationOfGiven<T> FailWith(string message)
+        {
+            if (evaluateCondition)
+            {
+                parentScope.FailWith(message, new object[0]);
+            }
+
+            return new ContinuationOfGiven<T>(this, parentScope);
+        }
     }
 }


### PR DESCRIPTION
(This is my first github pull request, so please bear with me)

I was unable to compile the develop branch in 26be9f6295d9b3ab6cbca8b4ee800fd9ca5674ae due to overload resolution on FailWith.