### PR TITLE
Add serialization constructor for AssertionFailedException

### DIFF
--- a/FluentAssertions.Net40/Net40.csproj
+++ b/FluentAssertions.Net40/Net40.csproj
@@ -27,7 +27,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -39,7 +39,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Package\Lib\net40\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\Package\Lib\net40\FluentAssertions.xml</DocumentationFile>

--- a/FluentAssertions.Shared.Specs/EventAssertionSpecs.cs
+++ b/FluentAssertions.Shared.Specs/EventAssertionSpecs.cs
@@ -3,6 +3,11 @@ using System.ComponentModel;
 using FluentAssertions.Events;
 using FluentAssertions.Formatting;
 
+#if NET40 || NET45
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using FluentAssertions.Execution;
+#endif
 
 #if !OLD_MSTEST
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
@@ -578,7 +583,6 @@ namespace FluentAssertions.Specs
         }
 
 #if NET40 || NET45
-
         [TestMethod]
         public void When_the_fallback_assertion_exception_crosses_appdomain_boundaries_it_should_be_serializable()
         {
@@ -586,6 +590,43 @@ namespace FluentAssertions.Specs
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
             new AssertFailedException("").Should().BeBinarySerializable();
+        }
+
+        [TestMethod]
+        public void When_the_fallback_assertion_exception_crosses_appdomain_boundaries_it_should_be_deserializable()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //----------------------------------------------------------------------------------------------------------
+            Exception exception = new AssertionFailedException("Message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+
+            // Save the full ToString() value, including the exception message and stack trace.
+            string exceptionToString = exception.ToString();
+
+            // Round-trip the exception: Serialize and de-serialize with a BinaryFormatter
+            BinaryFormatter formatter = new BinaryFormatter();
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                // "Save" object state
+                formatter.Serialize(memoryStream, exception);
+
+                // Re-use the same stream for de-serialization
+                memoryStream.Seek(0, 0);
+
+                // Replace the original exception with de-serialized one
+                exception = (AssertionFailedException)formatter.Deserialize(memoryStream);
+            }
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+
+            // Double-check that the exception message and stack trace (owned by the base Exception) are preserved
+            Assert.AreEqual(exceptionToString, exception.ToString(), "exception.ToString()");
         }
 
 #endif

--- a/Shared/Execution/AssertionFailedException.cs
+++ b/Shared/Execution/AssertionFailedException.cs
@@ -1,5 +1,9 @@
 using System;
 
+#if NET40 || NET45
+using System.Runtime.Serialization;
+#endif
+
 namespace FluentAssertions.Execution
 {
     /// <summary>
@@ -14,5 +18,14 @@ namespace FluentAssertions.Execution
         {
             
         }
+
+#if NET40 || NET45
+        protected AssertionFailedException(SerializationInfo info, StreamingContext context) 
+            : base(info, context)
+        {
+
+        }
+#endif
+
     }
 }


### PR DESCRIPTION
Currently the AssertionFailedException is missing a serializable constructor. Therefore it throws an error when deserializing the exception.

See: http://stackoverflow.com/questions/94488/what-is-the-correct-way-to-make-a-custom-net-exception-serializable

Addition to implement #214 properly
Clean PR of #262