### PR TITLE
Added support for recursively comparing two multi-dimensional arrays …

### DIFF
--- a/FluentAssertions.Core/Core.csproj
+++ b/FluentAssertions.Core/Core.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Common\NullReflector.cs" />
     <Compile Include="Common\PlatformAdapter.cs" />
     <Compile Include="Common\ProbingAdapterResolver.cs" />
+    <Compile Include="Equivalency\MultiDimensionalArrayEquivalencyStep.cs" />
     <Compile Include="Equivalency\Selection\AllPublicFieldsSelectionRule.cs" />
     <Compile Include="EquivalencyStepCollection.cs" />
     <Compile Include="Equivalency\AssertionContext.cs" />

--- a/FluentAssertions.Core/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/FluentAssertions.Core/Equivalency/EnumerableEquivalencyValidator.cs
@@ -108,7 +108,7 @@ namespace FluentAssertions.Equivalency
         {
             using (var scope = new AssertionScope())
             {
-                parent.AssertEqualityUsing(context.CreateForCollectionItem(expectationIndex, subject, expectation));
+                parent.AssertEqualityUsing(context.CreateForCollectionItem(expectationIndex.ToString(), subject, expectation));
 
                 return scope.Discard();
             }
@@ -116,7 +116,7 @@ namespace FluentAssertions.Equivalency
 
         private void StrictlyMatchAgainst<T>(T[] subjects, object expectation, int expectationIndex)
         {
-            parent.AssertEqualityUsing(context.CreateForCollectionItem(expectationIndex, subjects[expectationIndex], expectation));
+            parent.AssertEqualityUsing(context.CreateForCollectionItem(expectationIndex.ToString(), subjects[expectationIndex], expectation));
         }
     }
 }

--- a/FluentAssertions.Core/Equivalency/EquivalencyValidationContext.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyValidationContext.cs
@@ -5,6 +5,8 @@ namespace FluentAssertions.Equivalency
 {
     public class EquivalencyValidationContext : IEquivalencyValidationContext
     {
+        private Type compileTimeType;
+
         public EquivalencyValidationContext()
         {
             SelectedMemberDescription = "";
@@ -80,10 +82,17 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Gets the compile-time type of the current object. If the current object is not the root object, then it returns the 
-        /// same <see cref="Type"/> as the <see cref="ISubjectInfo.RuntimeType"/> property does.
+        /// Gets the compile-time type of the current object. If the current object is not the root object and the type is not <see cref="object"/>, 
+        /// then it returns the same <see cref="Type"/> as the <see cref="ISubjectInfo.RuntimeType"/> property does.
         /// </summary>
-        public Type CompileTimeType { get; set; }
+        public Type CompileTimeType
+        {
+            get { return (compileTimeType != typeof (object)) ? compileTimeType : RuntimeType; }
+            set
+            {
+                compileTimeType = value;
+            }
+        }
 
         /// <summary>
         /// Gets the run-time type of the current object.

--- a/FluentAssertions.Core/Equivalency/EquivalencyValidationContextExtentions.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyValidationContextExtentions.cs
@@ -26,7 +26,7 @@ namespace FluentAssertions.Equivalency
         }
 
         internal static IEquivalencyValidationContext CreateForCollectionItem<T>(this IEquivalencyValidationContext context,
-            int index, T subject, object expectation)
+            string index, T subject, object expectation)
         {
             string memberDescription = "[" + index + "]";
             string propertyPath = (context.SelectedMemberDescription.Length == 0) ? "item" : context.SelectedMemberDescription + String.Empty;

--- a/FluentAssertions.Core/Equivalency/ISubjectInfo.cs
+++ b/FluentAssertions.Core/Equivalency/ISubjectInfo.cs
@@ -44,8 +44,8 @@ namespace FluentAssertions.Equivalency
         string PropertyDescription { get; }
 
         /// <summary>
-        /// Gets the compile-time type of the current object. If the current object is not the root object, then it returns the 
-        /// same <see cref="Type"/> as the <see cref="RuntimeType"/> property does.
+        /// Gets the compile-time type of the current object. If the current object is not the root object and the type is not <see cref="object"/>, 
+        /// then it returns the same <see cref="Type"/> as the <see cref="ISubjectInfo.RuntimeType"/> property does.
         /// </summary>
         Type CompileTimeType { get; }
 

--- a/FluentAssertions.Core/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency
+{
+    /// <summary>
+    /// Supports recursively comparing two multi-dimensional arrays for equivalency using strict order for the array items 
+    /// themselves.
+    /// </summary>
+    internal class MultiDimensionalArrayEquivalencyStep : IEquivalencyStep
+    {
+        public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            Array array = context.Subject as Array;
+            return (array != null) && (array.Rank > 1);
+        }
+
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent,
+            IEquivalencyAssertionOptions config)
+        {
+            Array subjectAsArray = (Array) context.Subject;
+
+            if (AreComparable(context, subjectAsArray))
+            {
+                Digit digit = BuildDigitsRepresentingAllIndices(subjectAsArray);
+
+                do
+                {
+                    var expectation = ((Array) context.Expectation).GetValue(digit.Indices);
+                    IEquivalencyValidationContext itemContext = context.CreateForCollectionItem(
+                        string.Join(",", digit.Indices),
+                        subjectAsArray.GetValue(digit.Indices),
+                        expectation);
+
+                    parent.AssertEqualityUsing(itemContext);
+                }
+                while (digit.Increment());
+            }
+
+            return true;
+        }
+
+        private static Digit BuildDigitsRepresentingAllIndices(Array subjectAsArray)
+        {
+            return Enumerable
+                .Range(0, subjectAsArray.Rank)
+                .Reverse()
+                .Aggregate((Digit) null, (next, rank) => new Digit(subjectAsArray.GetLength(rank), next));
+        }
+
+        private static bool AreComparable(IEquivalencyValidationContext context, Array subjectAsArray)
+        {
+            return
+                IsArray(context.Expectation) &&
+                HaveSameRank(context.Expectation, subjectAsArray) &&
+                HaveSameDimensions(context.Expectation, subjectAsArray);
+        }
+
+        private static bool IsArray(object expectation)
+        {
+            return AssertionScope.Current
+                .ForCondition(!ReferenceEquals(expectation, null))
+                .FailWith("Can't compare a multi-dimensional array to {0}.", new object[] {null})
+                .Then
+                .ForCondition(expectation is Array)
+                .FailWith("Can't compare a multi-dimensional array to something else.");
+        }
+
+        private static bool HaveSameDimensions(object expectation, Array actual)
+        {
+            bool sameDimensions = true;
+
+            for (int dimension = 0; dimension < actual.Rank; dimension++)
+            {
+                int expectedLength = ((Array) expectation).GetLength(dimension);
+                int actualLength = actual.GetLength(dimension);
+
+                sameDimensions = sameDimensions & AssertionScope.Current
+                    .ForCondition(expectedLength == actualLength)
+                    .FailWith("Expected dimension {0} to contain {1} item(s), but found {2}.", dimension, expectedLength,
+                        actualLength);
+            }
+
+            return sameDimensions;
+        }
+
+        private static bool HaveSameRank(object expectation, Array actual)
+        {
+            var expectationAsArray = (Array) expectation;
+
+            return AssertionScope.Current
+                .ForCondition(actual.Rank == expectationAsArray.Rank)
+                .FailWith("Expected {context:array} to have {0} dimension(s), but it has {1}.", expectationAsArray.Rank,
+                    actual.Rank);
+        }
+    }
+
+    internal class Digit
+    {
+        private readonly int length;
+        private readonly Digit nextDigit;
+        private int index;
+
+        public Digit(int length, Digit nextDigit)
+        {
+            this.length = length;
+            this.nextDigit = nextDigit;
+        }
+
+        public int[] Indices
+        {
+            get
+            {
+                var indices = new List<int>();
+
+                Digit digit = this;
+                while (digit != null)
+                {
+                    indices.Add(digit.index);
+                    digit = digit.nextDigit;
+                }
+
+                return indices.ToArray();
+            }
+        }
+
+        public bool Increment()
+        {
+            bool success = (nextDigit != null) && nextDigit.Increment();
+            if (!success)
+            {
+                if (index < (length - 1))
+                {
+                    index++;
+                    success = true;
+                }
+                else
+                {
+                    index = 0;
+                }
+            }
+
+            return success;
+        }
+    }
+}

--- a/FluentAssertions.Core/EquivalencyStepCollection.cs
+++ b/FluentAssertions.Core/EquivalencyStepCollection.cs
@@ -110,6 +110,7 @@ namespace FluentAssertions
             yield return new RunAllUserStepsEquivalencyStep();
             yield return new GenericDictionaryEquivalencyStep();
             yield return new DictionaryEquivalencyStep();
+            yield return new MultiDimensionalArrayEquivalencyStep();
             yield return new GenericEnumerableEquivalencyStep();
             yield return new EnumerableEquivalencyStep();
             yield return new StringEqualityEquivalencyStep();

--- a/FluentAssertions.Core/Execution/Continuation.cs
+++ b/FluentAssertions.Core/Execution/Continuation.cs
@@ -26,6 +26,11 @@ namespace FluentAssertions.Execution
             get { return new AssertionScope(sourceScope, sourceSucceeded); }
         }
 
+        public bool SourceSucceeded
+        {
+            get { return sourceSucceeded; }
+        }
+
         /// <summary>
         /// Provides back-wards compatibility for code that expects <see cref="AssertionScope.FailWith"/> to return a boolean.
         /// </summary>

--- a/FluentAssertions.Core/Execution/ContinuationOfGiven.cs
+++ b/FluentAssertions.Core/Execution/ContinuationOfGiven.cs
@@ -8,14 +8,14 @@ namespace FluentAssertions.Execution
         #region Private Definitions
 
         private readonly GivenSelector<TSubject> parent;
-        private readonly AssertionScope scope;
+        private readonly bool succeeded;
 
         #endregion
 
-        public ContinuationOfGiven(GivenSelector<TSubject> parent, AssertionScope scope)
+        public ContinuationOfGiven(GivenSelector<TSubject> parent, bool succeeded)
         {
             this.parent = parent;
-            this.scope = scope;
+            this.succeeded = succeeded;
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace FluentAssertions.Execution
         /// </summary>
         public static implicit operator bool(ContinuationOfGiven<TSubject> continuationOfGiven)
         {
-            return continuationOfGiven.scope.Succeeded;
+            return continuationOfGiven.succeeded;
         }
     }
 }

--- a/FluentAssertions.Core/Execution/GivenSelector.cs
+++ b/FluentAssertions.Core/Execution/GivenSelector.cs
@@ -65,6 +65,20 @@ namespace FluentAssertions.Execution
         /// prior call to to <see cref="WithExpectation"/>.
         /// </summary>
         /// <remarks>
+        /// If an expectation was set through a prior call to <see cref="WithExpectation"/>, then the failure message is appended to that
+        /// expectation. 
+        /// </remarks>
+        /// <param name="message">The format string that represents the failure message.</param>
+        public ContinuationOfGiven<T> FailWith(string message)
+        {
+            return FailWith(message, new object[0]);
+        }
+
+        /// <summary>
+        /// Sets the failure message when the assertion is not met, or completes the failure message set to a 
+        /// prior call to to <see cref="WithExpectation"/>.
+        /// </summary>
+        /// <remarks>
         /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few 
         /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed 
         /// to <see cref="BecauseOf"/>. Other named placeholders will be replaced with the <see cref="Current"/> scope data 
@@ -79,12 +93,7 @@ namespace FluentAssertions.Execution
         /// <param name="args">Optional arguments to any numbered placeholders.</param>
         public ContinuationOfGiven<T> FailWith(string message, params Func<T, object>[] args)
         {
-            if (evaluateCondition)
-            {
-                parentScope.FailWith(message, args.Select(a => a(subject)).ToArray());
-            }
-            
-            return new ContinuationOfGiven<T>(this, parentScope);
+            return FailWith(message, args.Select(a => a(subject)).ToArray());
         }
 
         /// <summary>
@@ -106,31 +115,15 @@ namespace FluentAssertions.Execution
         /// <param name="args">Optional arguments to any numbered placeholders.</param>
         public ContinuationOfGiven<T> FailWith(string message, params object[] args)
         {
+            bool succeeded = parentScope.Succeeded;
+
             if (evaluateCondition)
             {
-                parentScope.FailWith(message, args);
+                Continuation continuation = parentScope.FailWith(message, args);
+                succeeded = continuation.SourceSucceeded;
             }
 
-            return new ContinuationOfGiven<T>(this, parentScope);
-        }
-
-        /// <summary>
-        /// Sets the failure message when the assertion is not met, or completes the failure message set to a 
-        /// prior call to to <see cref="WithExpectation"/>.
-        /// </summary>
-        /// <remarks>
-        /// If an expectation was set through a prior call to <see cref="WithExpectation"/>, then the failure message is appended to that
-        /// expectation. 
-        /// </remarks>
-        /// <param name="message">The format string that represents the failure message.</param>
-        public ContinuationOfGiven<T> FailWith(string message)
-        {
-            if (evaluateCondition)
-            {
-                parentScope.FailWith(message, new object[0]);
-            }
-
-            return new ContinuationOfGiven<T>(this, parentScope);
+            return new ContinuationOfGiven<T>(this, succeeded);
         }
     }
 }

--- a/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
@@ -195,7 +195,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_equivalence_of_strings_typed_as_objects_it_should_fail()
+        public void When_asserting_equivalence_of_strings_typed_as_objects_it_should_compare_them_as_strings()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -214,11 +214,11 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.ShouldThrow<InvalidOperationException>("because, typed as object, there were no members to compare");
+            act.ShouldNotThrow();
         }
 
         [TestMethod]
-        public void When_asserting_equivalence_of_ints_typed_as_objects_it_should_fail()
+        public void When_asserting_equivalence_of_ints_typed_as_objects_it_should_use_the_runtime_type()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -235,7 +235,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.ShouldThrow<InvalidOperationException>("because, typed as object, there were no members to compare");
+            act.ShouldNotThrow();
         }
 
         [TestMethod]
@@ -2920,7 +2920,7 @@ With configuration:*");
         }
 
         [TestMethod]
-        public void When_asserting_instances_of_arrays_of_types_in_System_are_equivalent_it_should_respect_the_declared_type()
+        public void When_asserting_instances_of_arrays_of_types_in_System_are_equivalent_it_should_respect_the_runtime_type()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -2936,7 +2936,7 @@ With configuration:*");
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.ShouldThrow<InvalidOperationException>();
+            act.ShouldNotThrow();
         }
 
         #endregion

--- a/FluentAssertions.Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/CollectionEquivalencySpecs.cs
@@ -104,7 +104,7 @@ namespace FluentAssertions.Specs
         #region Non-Generic Collections
 
         [TestMethod]
-        public void When_asserting_equivalence_of_collections_it_should_respect_the_declared_type()
+        public void When_asserting_equivalence_of_non_generic_collections_it_should_respect_the_runtime_type()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -120,7 +120,8 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.ShouldNotThrow("the declared type is object");
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("*Wheels*not have*VehicleId*not have*");
         }
 
         [TestMethod]
@@ -257,9 +258,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void
-            When_a_strongly_typed_collection_is_declared_as_an_untyped_collection_is_should_respect_the_declared_type
-            ()
+        public void When_a_strongly_typed_collection_is_declared_as_an_untyped_collection_is_should_respect_the_runtype_type()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -275,7 +274,8 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.ShouldNotThrow("the declared type is object");
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("*Wheels*not have*VehicleId*not have*");
         }
 
         [TestMethod]
@@ -589,12 +589,12 @@ namespace FluentAssertions.Specs
         private class MyChildObject
         {
             public int Id { get; set; }
-            
+
             public string MyChildString { get; set; }
 
             public override bool Equals(object obj)
             {
-                return (obj is MyChildObject) && (((MyChildObject)obj).Id == this.Id);
+                return (obj is MyChildObject) && (((MyChildObject) obj).Id == Id);
             }
 
             public override int GetHashCode()
@@ -614,7 +614,7 @@ namespace FluentAssertions.Specs
                 MyString = "identical string",
                 Child = new MyChildObject
                 {
-                    Id = 1, 
+                    Id = 1,
                     MyChildString = "identical string"
                 }
             };
@@ -629,8 +629,8 @@ namespace FluentAssertions.Specs
                 }
             };
 
-            IList<MyObject> actualList = new List<MyObject> { actual };
-            IList<MyObject> expectationList = new List<MyObject> { expectation };
+            IList<MyObject> actualList = new List<MyObject> {actual};
+            IList<MyObject> expectationList = new List<MyObject> {expectation};
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -2023,6 +2023,205 @@ namespace FluentAssertions.Specs
             }
         }
 
+        #endregion
+
+        #region Multi-dimensional Arrays
+
+        [TestMethod]
+        public void When_two_multi_dimensional_arrays_are_equivalent_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new[,]
+            {
+                {1, 2, 3},
+                {4, 5, 6}
+            };
+
+            var expectation = new[,]
+            {
+                {1, 2, 3},
+                {4, 5, 6}
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.ShouldBeEquivalentTo(expectation);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_two_multi_dimensional_arrays_are_not_equivalent_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new[,]
+            {
+                {1, 2, 3},
+                {4, 5, 6}
+            };
+
+            var expectation = new[,]
+            {
+                {1, 2, 4},
+                {4, -5, 6}
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.ShouldBeEquivalentTo(expectation);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("*item[0,2]*4*3*item[1,1]*-5*5*");
+        }
+
+        [TestMethod]
+        public void When_the_number_of_dimensions_of_the_arrays_are_not_the_same_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new[,]
+            {
+                {1, 2, 3},
+                {4, 5, 6}
+            };
+
+            var expectation = new[]
+            {
+                1, 2
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.ShouldBeEquivalentTo(expectation);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected*1 dimension(s), but*2*");
+        }
+        
+        [TestMethod]
+        public void When_the_expectation_is_not_a_multi_dimensional_array_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new[,]
+            {
+                {1, 2, 3},
+                {4, 5, 6}
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.ShouldBeEquivalentTo("not-a-multi-dimensional-array");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Can't compare a multi-dimensional array to something else.*");
+        }
+
+        [TestMethod]
+        public void When_the_expectation_is_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new[,]
+            {
+                {1, 2, 3},
+                {4, 5, 6}
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.ShouldBeEquivalentTo(null);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Can't compare a multi-dimensional array to <null>*");
+        }
+
+        [TestMethod]
+        public void When_the_length_of_the_first_dimension_differs_between_the_arrays_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new[,]
+            {
+                {1, 2, 3},
+                {4, 5, 6}
+            };
+
+            var expectation = new[,]
+            {
+                {1, 2},
+                {4, 5}
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.ShouldBeEquivalentTo(expectation);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected dimension 1 to contain 2 item(s), but found 3*");
+        }
+        
+        [TestMethod]
+        public void When_the_length_of_the_2nd_dimension_differs_between_the_arrays_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new[,]
+            {
+                {1, 2, 3},
+                {4, 5, 6}
+            };
+
+            var expectation = new[,]
+            {
+                {1, 2, 3},
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.ShouldBeEquivalentTo(expectation);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected dimension 0 to contain 1 item(s), but found 2*");
+        }
+        
         #endregion
     }
 }

--- a/FluentAssertions.Shared.Specs/DictionaryEquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/DictionaryEquivalencySpecs.cs
@@ -34,7 +34,8 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.ShouldNotThrow("the declared type of the items is object");
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("*Wheels*not have*VehicleId*not have*");
         }
 
         [TestMethod]
@@ -61,7 +62,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_a_non_generic_dictionary_is_typed_as_object_and_runtime_typing_has_not_been_specified_the_declared_type_should_be_respected()
+        public void When_a_non_generic_dictionary_is_typed_as_object_it_should_respect_the_runtime_type()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -77,7 +78,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.ShouldThrow<InvalidOperationException>("the type of the subject is object");
+            act.ShouldNotThrow();
         }
 
         [TestMethod]
@@ -119,7 +120,8 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.ShouldNotThrow("the declared type of the values is 'object'");
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("*Other*Special*");
         }
 
         private class NonGenericDictionary : IDictionary
@@ -364,7 +366,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_a_generic_dictionary_is_typed_as_object_and_runtime_typing_has_not_been_specified_the_declared_type_should_be_respected()
+        public void When_a_generic_dictionary_is_typed_as_object_it_should_respect_the_runtime_typed()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -380,7 +382,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.ShouldThrow<InvalidOperationException>("the type of the subject is object");
+            act.ShouldNotThrow();
         }
 
         [TestMethod]

--- a/FluentAssertions.sln.DotSettings
+++ b/FluentAssertions.sln.DotSettings
@@ -6,6 +6,7 @@
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_WHILE_ON_NEW_LINE/@EntryValue">True</s:Boolean>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">130</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>


### PR DESCRIPTION
…for equivalency. Should fix #260.

Fixed a bug when chaining multiple assertions together.
During equivalency assertions, a declared type of object is still processed as a run-time type.