### PR TITLE
Allow SelfReferencingCollectionAssertions to compare collections of different types using predicate

### DIFF
--- a/Src/Core/Collections/CollectionAssertions.cs
+++ b/Src/Core/Collections/CollectionAssertions.cs
@@ -201,12 +201,12 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> Equal(IEnumerable expected, string because = "", params object[] reasonArgs)
         {
-            AssertSubjectEquality<object>(expected, (s, e) => s.IsSameOrEqualTo(e), because, reasonArgs);
+            AssertSubjectEquality<object, object>(expected, (s, e) => s.IsSameOrEqualTo(e), because, reasonArgs);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
-        protected void AssertSubjectEquality<T>(IEnumerable expectation, Func<T, T, bool> predicate,
+        protected void AssertSubjectEquality<TActual, TExpected>(IEnumerable expectation, Func<TActual, TExpected, bool> predicate,
             string because = "", params object[] reasonArgs)
         {
             AssertionScope assertion = Execute.Assertion.BecauseOf(because, reasonArgs);
@@ -229,8 +229,8 @@ namespace FluentAssertions.Collections
                 throw new ArgumentNullException("expectation", "Cannot compare collection with <null>.");
             }
 
-            T[] expectedItems = expectation.Cast<T>().ToArray();
-            T[] actualItems = Subject.Cast<T>().ToArray();
+            TExpected[] expectedItems = expectation.Cast<TExpected>().ToArray();
+            TActual[] actualItems = Subject.Cast<TActual>().ToArray();
 
             AssertCollectionsHaveSameCount(expectedItems, actualItems, assertion);
 
@@ -243,7 +243,7 @@ namespace FluentAssertions.Collections
             }
         }
 
-        private void AssertCollectionsHaveSameCount<T>(T[] expectedItems, T[] actualItems, AssertionScope assertion)
+        private void AssertCollectionsHaveSameCount<TActual, TExpected>(TExpected[] expectedItems, TActual[] actualItems, AssertionScope assertion)
         {
             int delta = Math.Abs(expectedItems.Length - actualItems.Length);
             if (delta != 0)

--- a/Src/Core/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/Core/Collections/SelfReferencingCollectionAssertions.cs
@@ -121,8 +121,8 @@ namespace FluentAssertions.Collections
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
-        public AndConstraint<TAssertions> Equal(
-            IEnumerable<T> expectation, Func<T, T, bool> predicate, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> Equal<TExpected>(
+            IEnumerable<TExpected> expectation, Func<T, TExpected, bool> predicate, string because = "", params object[] reasonArgs)
         {
             AssertSubjectEquality(expectation, predicate, because, reasonArgs);
 

--- a/Tests/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
@@ -871,13 +871,19 @@ namespace FluentAssertions.Specs
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
            var actual = new List<string> { "ONE", "TWO", "THREE", "FOUR" }; 
-           var expected = new List<string> { "One", "Two", "Three", "Four" }; 
+           var expected = new []
+           {
+               new { Value = "One" },
+               new { Value = "Two" },
+               new { Value = "Three" },
+               new { Value = "Four" }
+           }; 
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => actual.Should().Equal(expected,
-                (a, e) => string.Equals(a, e, StringComparison.CurrentCultureIgnoreCase));
+                (a, e) => string.Equals(a, e.Value, StringComparison.CurrentCultureIgnoreCase));
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -892,13 +898,19 @@ namespace FluentAssertions.Specs
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             var actual = new List<string> { "ONE", "TWO", "THREE", "FOUR" };
-            var expected = new List<string> { "One", "Two", "Three", "Five" };
+            var expected = new[]
+            {
+               new { Value = "One" },
+               new { Value = "Two" },
+               new { Value = "Three" },
+               new { Value = "Five" }
+           };
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => actual.Should().Equal(expected,
-                (a, e) => string.Equals(a, e, StringComparison.CurrentCultureIgnoreCase));
+                (a, e) => string.Equals(a, e.Value, StringComparison.CurrentCultureIgnoreCase));
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert


### PR DESCRIPTION
Sometimes it is required to verify collection of objects that have no public constructor and not abstracted by interface, so there is no way to create an expected collection of objects of exactly the same type. In this case, it is useful to compare it with collection of anonymous objects that contain all required data:
```c#
IList<TypeWithPrivateCtor> actual = GetActual();
var expected = new [] 
{
   new { P1 = "a", P2 = 0 },
   new { P1 = "b", P2 = 1 },
   new { P1 = "c", P2 = 2 },
}
actual.Should().Equal(expected, (a, e) => a.P1 == e.P1 && a.P2 == e.P2);
```