### PR TITLE
Added failing test for parallel execution of event monitoring.

### DIFF
--- a/Tests/FluentAssertions.Shared.Specs/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/EventAssertionSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.ComponentModel;
 using FluentAssertions.Events;
 using FluentAssertions.Formatting;
@@ -304,6 +305,33 @@ namespace FluentAssertions.Specs
             Action act = () => subject
                 .ShouldRaise("PropertyChanged")
                 .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "SomeProperty");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_running_in_parallel_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //----------------------------------------------------------------------------------------------------------
+            Action<int> action = i =>
+            {
+                EventRaisingClass subject = new EventRaisingClass();
+                subject.MonitorEvents();
+                subject.RaiseEventWithSender();
+                subject.ShouldRaise("PropertyChanged");
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => Enumerable.Range(0, 1000)
+                .AsParallel()
+                .ForAll(action);
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert


### PR DESCRIPTION
Unfortunately, event monitoring seems to use unsynchronized access to static members. This leads to multithreading problems whenever a test runner happens to execute tests in parallel, as xUnit 2 does for instance.

This pull requests adds a unit test that shows the behavior by running .MonitorEvents() 1000 times, using Parallel LINQ. On a default Azure A2 development machine, this would reproduce the issue every time.