### PR TITLE
monitor events for implemented interface or base class only

### DIFF
--- a/Src/Shared/AssertionExtensions.cs
+++ b/Src/Shared/AssertionExtensions.cs
@@ -611,9 +611,10 @@ namespace FluentAssertions
 
 #if !SILVERLIGHT && !WINRT && !PORTABLE && !CORE_CLR
         /// <summary>
-        ///   Starts monitoring an object for its events.
+        ///   Starts monitoring <paramref name="eventSource"/> for its events.
         /// </summary>
-        /// <exception cref = "ArgumentNullException">Thrown if eventSource is Null.</exception>
+        /// <param name="eventSource">The object for which to monitor the events.</param>
+        /// <exception cref = "ArgumentNullException">Thrown if <paramref name="eventSource"/> is Null.</exception>
         public static void MonitorEvents(this object eventSource)
         {
             // SMELL: This static stuff needs to go at the some point. 
@@ -621,9 +622,11 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        ///   Starts monitoring an object for events defined in the type parameter T.
+        ///   Starts monitoring <paramref name="eventSource"/> for events defined in the type parameter <typeparamref name="T"/>.
         /// </summary>
-        /// <exception cref = "ArgumentNullException">Thrown if eventSource is Null.</exception>
+        /// <param name="eventSource">The object for which to monitor the events.</param>
+        /// <typeparam name="T">The type defining the events it should monitor.</typeparam>
+        /// <exception cref = "ArgumentNullException">Thrown if <paramref name="eventSource"/> is Null.</exception>
         public static void MonitorEvents<T>(this object eventSource)
         {
             // SMELL: This static stuff needs to go at the some point. 

--- a/Src/Shared/AssertionExtensions.cs
+++ b/Src/Shared/AssertionExtensions.cs
@@ -617,13 +617,17 @@ namespace FluentAssertions
         public static void MonitorEvents(this object eventSource)
         {
             // SMELL: This static stuff needs to go at the some point. 
-            EventMonitor.AddRecordersFor(eventSource, o => BuildRecorders(o, o.GetType()));
+            EventMonitor.AddRecordersFor(eventSource, source => BuildRecorders(source, source.GetType()));
         }
 
+        /// <summary>
+        ///   Starts monitoring an object for events defined in the type parameter T.
+        /// </summary>
+        /// <exception cref = "ArgumentNullException">Thrown if eventSource is Null.</exception>
         public static void MonitorEvents<T>(this object eventSource)
         {
             // SMELL: This static stuff needs to go at the some point. 
-            EventMonitor.AddRecordersFor(eventSource, o => BuildRecorders(o, typeof(T)));
+            EventMonitor.AddRecordersFor(eventSource, source => BuildRecorders(source, typeof(T)));
         }
 
         private static EventRecorder[] BuildRecorders(object eventSource, Type eventSourceType)

--- a/Tests/FluentAssertions.Shared.Specs/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/EventAssertionSpecs.cs
@@ -8,10 +8,15 @@ using FluentAssertions.Formatting;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using FluentAssertions.Execution;
+using System.Reflection.Emit;
+using System.Linq.Expressions;
+using System.Reflection;
 #endif
 
 #if !OLD_MSTEST
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using System.Reflection.Emit;
+using System.Reflection;
 #else
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
@@ -366,7 +371,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldNotThrow();
         }
-        
+
         [TestMethod]
         public void When_an_expected_property_changed_event_was_raised_for_all_properties_it_should_not_throw()
         {
@@ -432,7 +437,7 @@ namespace FluentAssertions.Specs
                 "Expected object " + Formatter.ToString(subject) +
                     " to raise event \"PropertyChanged\" for property \"SomeProperty\" because the property was changed, but it did not.");
         }
-        
+
         [TestMethod]
         public void When_a_property_agnostic_property_changed_event_for_was_not_raised_it_should_throw()
         {
@@ -520,7 +525,7 @@ namespace FluentAssertions.Specs
             recorder.EventObject.Should().BeSameAs(eventSource);
             recorder.EventName.Should().Be("PropertyChanged");
         }
-        
+
         [TestMethod]
         public void When_a_class_is_not_being_monitored_it_should_not_be_possible_to_get_a_recorder()
         {
@@ -540,7 +545,7 @@ namespace FluentAssertions.Specs
             action.ShouldThrow<InvalidOperationException>()
                 .WithMessage("*not being monitored*");
         }
-        
+
         [TestMethod]
         public void When_no_recorder_exists_for_an_event_it_should_throw()
         {
@@ -560,6 +565,70 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             action.ShouldThrow<InvalidOperationException>()
                 .WithMessage("*not expose*SomeEvent*");
+        }
+
+        [TestMethod]
+        public void When_monitoring_interface_of_a_class_it_should_be_possible_to_obtain_a_recorder()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var eventSource = CreateProxyObject();
+            eventSource.MonitorEvents<IEventRaisingInterface>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            var recorder = eventSource.GetRecorderForEvent("InterfaceEvent");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            recorder.Should().NotBeNull();
+            recorder.EventObject.Should().BeSameAs(eventSource);
+            recorder.EventName.Should().Be("InterfaceEvent");
+        }
+
+        [TestMethod]
+        public void When_monitoring_interface_of_a_class_and_no_recorder_exists_for_an_event_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var eventSource = CreateProxyObject();
+            eventSource.MonitorEvents<IEventRaisingInterface>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => eventSource.GetRecorderForEvent("SomeEvent");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<InvalidOperationException>()
+                .WithMessage("*not expose*SomeEvent*");
+        }
+
+        [TestMethod]
+        public void When_monitoring_interface_of_a_class_and_no_recorder_exists_for_an_event_in_interface_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var eventSource = CreateProxyObject();
+            eventSource.MonitorEvents<IEventRaisingInterface>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => eventSource.GetRecorderForEvent("PropertyChanged");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<InvalidOperationException>()
+                .WithMessage("*not expose*PropertyChanged*");
         }
 
 
@@ -661,7 +730,7 @@ namespace FluentAssertions.Specs
 
         #endregion
 
-        internal class EventRaisingClass : INotifyPropertyChanged
+        public class EventRaisingClass : INotifyPropertyChanged
         {
             public string SomeProperty { get; set; }
             public event PropertyChangedEventHandler PropertyChanged = delegate { };
@@ -680,6 +749,42 @@ namespace FluentAssertions.Specs
             {
                 PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
             }
+        }
+
+        public interface IEventRaisingInterface
+        {
+            event EventHandler InterfaceEvent;
+        }
+
+        private object CreateProxyObject()
+        {
+            Type baseType = typeof(EventRaisingClass);
+            Type interfaceType = typeof(IEventRaisingInterface);
+            var assemblyName = new AssemblyName();
+            assemblyName.Name = baseType.Assembly.FullName + ".GeneratedForTest";
+            var assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name, false);
+            string typeName = baseType.Name + "_GeneratedForTest";
+            TypeBuilder typeBuilder = moduleBuilder.DefineType(typeName, TypeAttributes.Public, baseType, new Type[] { interfaceType });
+
+            Func<string, MethodBuilder> emitAddRemoveEventHandler = (methodName) =>
+            {
+                MethodBuilder method = typeBuilder.DefineMethod(interfaceType.FullName + "." + methodName + "_InterfaceEvent",
+                    MethodAttributes.Private | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot);
+                method.SetReturnType(typeof(void));
+                method.SetParameters(typeof(EventHandler));
+                ParameterBuilder value = method.DefineParameter(1, ParameterAttributes.None, "value");
+                ILGenerator gen = method.GetILGenerator();
+                gen.Emit(OpCodes.Ret);
+                return method;
+            };
+            var addHandler = emitAddRemoveEventHandler("add");
+            typeBuilder.DefineMethodOverride(addHandler, interfaceType.GetMethod("add_InterfaceEvent"));
+            var removeHandler = emitAddRemoveEventHandler("remove");
+            typeBuilder.DefineMethodOverride(removeHandler, interfaceType.GetMethod("remove_InterfaceEvent"));
+
+            Type generatedType = typeBuilder.CreateType();
+            return Activator.CreateInstance(generatedType);
         }
     }
 }

--- a/Tests/FluentAssertions.Shared.Specs/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/EventAssertionSpecs.cs
@@ -631,6 +631,26 @@ namespace FluentAssertions.Specs
                 .WithMessage("*not expose*PropertyChanged*");
         }
 
+        [TestMethod]
+        public void When_trying_to_monitor_events_of_unimplemented_interface_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var eventSource = CreateProxyObject();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => eventSource.MonitorEvents<IEventRaisingInterface2>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<TargetException>()
+                .WithMessage("*not match target type*");
+        }
+
 
         [TestMethod]
         public void When_a_monitored_class_in_not_referenced_anymore_it_should_be_garbage_collected()
@@ -754,6 +774,11 @@ namespace FluentAssertions.Specs
         public interface IEventRaisingInterface
         {
             event EventHandler InterfaceEvent;
+        }
+
+        public interface IEventRaisingInterface2
+        {
+            event EventHandler Interface2Event;
         }
 
         private object CreateProxyObject()


### PR DESCRIPTION
I added a new generic extension method MonitorEvents&lt;T&gt;. It works simmilar to MonitorEvents but it will only monitor events of type T. It is useful when you don't want to monitor all events of an object. It is very useful when monitoring events of an object created using System.Reflection.Emit. In this case MonitorEvents will not work because the events added using TypeBuilder will not be located using non-generic version of MonitorEvents. With generic version of MonitorEvents you can provide the interface implemented using TypeBuilder. Check the tests to see what I mean.