### PR TITLE
Added properties for the access modifier of getter and setter on SelectedMemberInfo

### DIFF
--- a/Src/Core/Common/CSharpAccessModifierExtensions.cs
+++ b/Src/Core/Common/CSharpAccessModifierExtensions.cs
@@ -35,6 +35,36 @@ namespace FluentAssertions.Common
             return CSharpAccessModifier.InvalidForCSharp;
         }
 
+        internal static CSharpAccessModifier GetCSharpAccessModifier(this FieldInfo fieldInfo)
+        {
+            if (fieldInfo.IsPrivate)
+            {
+                return CSharpAccessModifier.Private;
+            }
+
+            if (fieldInfo.IsFamily)
+            {
+                return CSharpAccessModifier.Protected;
+            }
+
+            if (fieldInfo.IsAssembly)
+            {
+                return CSharpAccessModifier.Internal;
+            }
+
+            if (fieldInfo.IsPublic)
+            {
+                return CSharpAccessModifier.Public;
+            }
+
+            if (fieldInfo.IsFamilyOrAssembly)
+            {
+                return CSharpAccessModifier.ProtectedInternal;
+            }
+
+            return CSharpAccessModifier.InvalidForCSharp;
+        }
+
         internal static CSharpAccessModifier GetCSharpAccessModifier(this Type type)
         {
             if (type.GetTypeInfo().IsNestedPrivate)

--- a/Src/Core/Core.projitems
+++ b/Src/Core/Core.projitems
@@ -106,6 +106,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Equivalency\SimpleEqualityEquivalencyStep.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Equivalency\StringEqualityEquivalencyStep.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Equivalency\StructuralEqualityEquivalencyStep.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Equivalency\SubjectInfoExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Equivalency\TryConversionEquivalencyStep.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Equivalency\ValueTypeEquivalencyStep.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Events\EventMonitor.cs" />

--- a/Src/Core/Equivalency/FieldSelectedMemberInfo.cs
+++ b/Src/Core/Equivalency/FieldSelectedMemberInfo.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency
 {
@@ -29,6 +30,16 @@ namespace FluentAssertions.Equivalency
         public override Type MemberType
         {
             get { return fieldInfo.FieldType; }
+        }
+
+        internal override CSharpAccessModifier GetAccessModifier
+        {
+            get { return fieldInfo.GetCSharpAccessModifier(); }
+        }
+
+        internal override CSharpAccessModifier SetAccessModifier
+        {
+            get { return fieldInfo.GetCSharpAccessModifier(); }
         }
     }
 }

--- a/Src/Core/Equivalency/PropertySelectedMemberInfo.cs
+++ b/Src/Core/Equivalency/PropertySelectedMemberInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency
 {
@@ -18,6 +19,16 @@ namespace FluentAssertions.Equivalency
         public override Type MemberType
         {
             get { return propertyInfo.PropertyType; }
+        }
+
+        internal override CSharpAccessModifier GetAccessModifier
+        {
+            get { return propertyInfo.GetGetMethod(true).GetCSharpAccessModifier(); }
+        }
+
+        internal override CSharpAccessModifier SetAccessModifier
+        {
+            get { return propertyInfo.GetSetMethod(true).GetCSharpAccessModifier(); }
         }
 
         public override object GetValue(object obj, object[] index)

--- a/Src/Core/Equivalency/SelectedMemberInfo.cs
+++ b/Src/Core/Equivalency/SelectedMemberInfo.cs
@@ -45,6 +45,16 @@ namespace FluentAssertions.Equivalency
         public abstract Type DeclaringType { get; }
 
         /// <summary>
+        /// Gets the access modifier for the getter of this member.
+        /// </summary>
+        internal abstract CSharpAccessModifier GetAccessModifier { get; }
+
+        /// <summary>
+        /// Gets the access modifier for the setter of this member.
+        /// </summary>
+        internal abstract CSharpAccessModifier SetAccessModifier { get; }
+
+        /// <summary>
         /// Returns the member value of a specified object with optional index values for indexed properties or methods.
         /// </summary>
         public abstract object GetValue(object obj, object[] index);

--- a/Src/Core/Equivalency/SubjectInfoExtensions.cs
+++ b/Src/Core/Equivalency/SubjectInfoExtensions.cs
@@ -1,0 +1,51 @@
+﻿using FluentAssertions.Common;
+
+namespace FluentAssertions.Equivalency
+{
+    public static class SubjectInfoExtensions
+    {
+        /// <summary>
+        /// Checks if the subject info setter has the given access modifier.
+        /// </summary>
+        /// <param name="subjectInfo">The subject info being checked.</param>
+        /// <param name="accessModifier">The access modifier that the subject info setter should have.</param>
+        /// <returns>True if the subject info setter has the given access modifier, false otherwise.</returns>
+        public static bool WhichSetterHas(this ISubjectInfo subjectInfo, CSharpAccessModifier accessModifier)
+        {
+            return subjectInfo.SelectedMemberInfo.SetAccessModifier == accessModifier;
+        }
+
+        /// <summary>
+        /// Checks if the subject info setter does not have the given access modifier.
+        /// </summary>
+        /// <param name="subjectInfo">The subject info being checked.</param>
+        /// <param name="accessModifier">The access modifier that the subject info setter should not have.</param>
+        /// <returns>True if the subject info setter does not have the given access modifier, false otherwise.</returns>
+        public static bool WhichSetterDoesNotHave(this ISubjectInfo subjectInfo, CSharpAccessModifier accessModifier)
+        {
+            return subjectInfo.SelectedMemberInfo.SetAccessModifier != accessModifier;
+        }
+
+        /// <summary>
+        /// Checks if the subject info getter has the given access modifier.
+        /// </summary>
+        /// <param name="subjectInfo">The subject info being checked.</param>
+        /// <param name="accessModifier">The access modifier that the subject info getter should have.</param>
+        /// <returns>True if the subject info getter has the given access modifier, false otherwise.</returns>
+        public static bool WhichGetterHas(this ISubjectInfo subjectInfo, CSharpAccessModifier accessModifier)
+        {
+            return subjectInfo.SelectedMemberInfo.GetAccessModifier == accessModifier;
+        }
+
+        /// <summary>
+        /// Checks if the subject info getter does not have the given access modifier.
+        /// </summary>
+        /// <param name="subjectInfo">The subject info being checked.</param>
+        /// <param name="accessModifier">The access modifier that the subject info getter should not have.</param>
+        /// <returns>True if the subject info getter does not have the given access modifier, false otherwise.</returns>
+        public static bool WhichGetterDoesNotHave(this ISubjectInfo subjectInfo, CSharpAccessModifier accessModifier)
+        {
+            return subjectInfo.SelectedMemberInfo.GetAccessModifier != accessModifier;
+        }
+    }
+}


### PR DESCRIPTION
I added properties to get the access modifiers of the getter and setter on `SelectedMemberInfo`.
For field members it uses the same access modifier for both the getter and setter.

```csharp
CSharpAccessModifier GetAccessModifier { get; }
// and
CSharpAccessModifier SetAccessModifier { get; }
```

Also added extension methods on `ISubjectInfo` for checking the access modifier of the setter or getter in a fluent manner:

- `subjectInfo.WhichSetterHas(CSharpAccessModifier)`
- `subjectInfo.WhichSetterDoesNotHave(CSharpAccessModifier)`
- `subjectInfo.WhichGetterHas(CSharpAccessModifier)`
- `subjectInfo.WhichGetterDoesNotHave(CSharpAccessModifier)`

Usage sample

```csharp
subject.ShouldBeEquivalentTo(expected, config =>
                config.Excluding(ctx => ctx.WhichGetterHas(CSharpAccessModifier.Internal) ||
                                        ctx.WhichGetterHas(CSharpAccessModifier.ProtectedInternal)))
```

The `GetAccessModifier` and `SetAccessModifier` properties can also be directly used from the equivalency check configurator as follows:

```csharp
subject.ShouldBeEquivalentTo(expected, config =>
                config.Excluding(ctx => ctx.SelectedMemberInfo.GetAccessModifier == CSharpAccessModifier.Internal ||
                                        ctx.SelectedMemberInfo.SetAccessModifier == CSharpAccessModifier.ProtectedInternal)
```