### PR TITLE
Fixed (non-)optional 'because' and 'reasonArgs' for Dictionaries

### DIFF
--- a/Src/Core/Collections/GenericDictionaryAssertions.cs
+++ b/Src/Core/Collections/GenericDictionaryAssertions.cs
@@ -312,7 +312,7 @@ namespace FluentAssertions.Collections
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> ContainKeys(IEnumerable<TKey> expected,
-            string because, params object[] reasonArgs)
+            string because = "", params object[] reasonArgs)
         {
             if (expected == null)
             {
@@ -448,8 +448,8 @@ namespace FluentAssertions.Collections
             return ContainValuesAndWhich(expected, because, reasonArgs);
         }
 
-        private AndWhichConstraint<GenericDictionaryAssertions<TKey, TValue>, IEnumerable<TValue>> ContainValuesAndWhich(IEnumerable<TValue> expected, string because,
-            object[] reasonArgs)
+        private AndWhichConstraint<GenericDictionaryAssertions<TKey, TValue>, IEnumerable<TValue>> ContainValuesAndWhich(IEnumerable<TValue> expected, string because = "",
+            params object[] reasonArgs)
         {
             if (expected == null)
             {


### PR DESCRIPTION
GenericDictionaryAssertions<,>.ContainKeys(..) had a non-optional 'because' argument and
so did .ContainValuesAndWhich(..) - more precisely, the later for 'reasonArgs'. Both were/are inconsistent with the rest (looked like an oversight - these two parameters are used optionally / as params[] everywhere else).

Cheers,
-J