### PR TITLE
Added GenericDictionaryAssertions .Contain(..) and .NotContain() that take an IEnumable<KeyValuePair<,,>>

### DIFF
--- a/Src/Core/Collections/GenericDictionaryAssertions.cs
+++ b/Src/Core/Collections/GenericDictionaryAssertions.cs
@@ -610,8 +610,8 @@ namespace FluentAssertions.Collections
                 {
                     Execute.Assertion
                         .BecauseOf(because, reasonArgs)
-                        .FailWith("Expected {context:dictionary} to contain {0}{reason}, but {1} differs at key {2}.",
-                            expectedKeyValuePairs, Subject, keyValuePairsNotSameOrEqualInSubject.Select(keyValuePair => keyValuePair.Key));
+                        .FailWith("Expected {context:dictionary} to contain {0}{reason}, but {context:dictionary} differs at keys {1}.",
+                            expectedKeyValuePairs, keyValuePairsNotSameOrEqualInSubject.Select(keyValuePair => keyValuePair.Key));
                 }
                 else
                 {

--- a/Src/Core/Collections/GenericDictionaryAssertions.cs
+++ b/Src/Core/Collections/GenericDictionaryAssertions.cs
@@ -551,7 +551,7 @@ namespace FluentAssertions.Collections
         /// Asserts that the current dictionary contains the specified <paramref name="expected"/>.
         /// Keys and values are compared using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
-        /// <param name="expected">The expected <see cref="KeyValuePair{TKey,TValue}">key value pairs</see></param>
+        /// <param name="expected">The expected key/value pairs.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -578,7 +578,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, reasonArgs)
-                    .FailWith("Expected {context:dictionary} to contain key value pairs {0}{reason}, but found {1}.", expected, Subject);
+                    .FailWith("Expected {context:dictionary} to contain key/value pairs {0}{reason}, but found {1}.", expected, Subject);
             }
 
             var expectedKeys = expectedKeyValuePairs.Select(keyValuePair => keyValuePair.Key).ToArray();
@@ -692,6 +692,68 @@ namespace FluentAssertions.Collections
         #endregion
 
         #region NotContain
+
+        /// <summary>
+        /// Asserts that the current dictionary does not contain the specified <paramref name="items"/>.
+        /// Keys and values are compared using their <see cref="object.Equals(object)" /> implementation.
+        /// </summary>
+        /// <param name="items">The unexpected key/value pairs</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="reasonArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(IEnumerable<KeyValuePair<TKey, TValue>> items,
+            string because = "", params object[] reasonArgs)
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException("items", "Cannot compare dictionary with <null>.");
+            }
+
+            KeyValuePair<TKey, TValue>[] keyValuePairs = items.ToArray();
+
+            if (!keyValuePairs.Any())
+            {
+                throw new ArgumentException("Cannot verify key containment against an empty dictionary");
+            }
+
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, reasonArgs)
+                    .FailWith("Expected {context:dictionary} not to contain key/value pairs {0}{reason}, but dictionary is {1}.", items, Subject);
+            }
+
+            var keyValuePairsFound = keyValuePairs.Where(keyValuePair => Subject.ContainsKey(keyValuePair.Key)).ToArray();
+
+            if (keyValuePairsFound.Any())
+            {
+                var keyValuePairsSameOrEqualInSubject = keyValuePairsFound.Where(keyValuePair => Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
+
+                if (keyValuePairsSameOrEqualInSubject.Any())
+                {
+                    if (keyValuePairsSameOrEqualInSubject.Count() > 1)
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, reasonArgs)
+                            .FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but found them anyhow.", keyValuePairs);
+                    }
+                    else
+                    {
+                        var keyValuePair = keyValuePairsSameOrEqualInSubject.First();
+                        
+                        Execute.Assertion
+                            .BecauseOf(because, reasonArgs)
+                            .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.", keyValuePair.Value, keyValuePair.Key);
+                    }
+                }
+            }
+
+            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+        }
 
         /// <summary>
         /// Asserts that the current dictionary does not contain the specified <paramref name="item"/>.

--- a/Src/Core/Collections/GenericDictionaryAssertions.cs
+++ b/Src/Core/Collections/GenericDictionaryAssertions.cs
@@ -551,6 +551,86 @@ namespace FluentAssertions.Collections
         /// Asserts that the current dictionary contains the specified <paramref name="expected"/>.
         /// Keys and values are compared using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
+        /// <param name="expected">The expected <see cref="KeyValuePair{TKey,TValue}">key value pairs</see></param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="reasonArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(IEnumerable<KeyValuePair<TKey, TValue>> expected,
+            string because = "", params object[] reasonArgs)
+        {
+            if (expected == null)
+            {
+                throw new ArgumentNullException("expected", "Cannot compare dictionary with <null>.");
+            }
+
+            KeyValuePair<TKey, TValue>[] expectedKeyValuePairs = expected.ToArray();
+
+            if (!expectedKeyValuePairs.Any())
+            {
+                throw new ArgumentException("Cannot verify key containment against an empty dictionary");
+            }
+
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, reasonArgs)
+                    .FailWith("Expected {context:dictionary} to contain key value pairs {0}{reason}, but found {1}.", expected, Subject);
+            }
+
+            var expectedKeys = expectedKeyValuePairs.Select(keyValuePair => keyValuePair.Key).ToArray();
+            var missingKeys = expectedKeys.Where(key => !Subject.ContainsKey(key));
+
+            if (missingKeys.Any())
+            {
+                if (expectedKeyValuePairs.Count() > 1)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, reasonArgs)
+                        .FailWith("Expected {context:dictionary} {0} to contain key(s) {1}{reason}, but could not find {2}.", Subject,
+                            expectedKeys, missingKeys);
+                }
+                else
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, reasonArgs)
+                        .FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}.", Subject,
+                            expectedKeys.Cast<object>().First());
+                }
+            }
+
+            var keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs.Where(keyValuePair => !Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
+
+            if (keyValuePairsNotSameOrEqualInSubject.Any())
+            {
+                if (expectedKeys.Count() > 1)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, reasonArgs)
+                        .FailWith("Expected {context:dictionary} to contain {0}{reason}, but {1} differs at key {2}.",
+                            expectedKeyValuePairs, Subject, keyValuePairsNotSameOrEqualInSubject.Select(keyValuePair => keyValuePair.Key));
+                }
+                else
+                {
+                    var expectedKeyValuePair = expectedKeyValuePairs.First();
+                    TValue actual = Subject[expectedKeyValuePair.Key];
+
+                    Execute.Assertion
+                        .BecauseOf(because, reasonArgs)
+                        .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.", expectedKeyValuePair.Value, expectedKeyValuePair.Key, actual);
+                }
+            }
+
+            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current dictionary contains the specified <paramref name="expected"/>.
+        /// Keys and values are compared using their <see cref="object.Equals(object)" /> implementation.
+        /// </summary>
         /// <param name="expected">The expected <see cref="KeyValuePair{TKey,TValue}"/></param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 

--- a/Src/Core/Collections/GenericDictionaryAssertions.cs
+++ b/Src/Core/Collections/GenericDictionaryAssertions.cs
@@ -602,7 +602,7 @@ namespace FluentAssertions.Collections
                 }
             }
 
-            var keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs.Where(keyValuePair => !Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
+            KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs.Where(keyValuePair => !Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
 
             if (keyValuePairsNotSameOrEqualInSubject.Any())
             {

--- a/Src/Core/Collections/GenericDictionaryAssertions.cs
+++ b/Src/Core/Collections/GenericDictionaryAssertions.cs
@@ -571,14 +571,14 @@ namespace FluentAssertions.Collections
 
             if (!expectedKeyValuePairs.Any())
             {
-                throw new ArgumentException("Cannot verify key containment against an empty dictionary");
+                throw new ArgumentException("Cannot verify key containment against an empty collection of key/value pairs");
             }
 
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
                     .BecauseOf(because, reasonArgs)
-                    .FailWith("Expected {context:dictionary} to contain key/value pairs {0}{reason}, but found {1}.", expected, Subject);
+                    .FailWith("Expected {context:dictionary} to contain key/value pairs {0}{reason}, but dictionary is {1}.", expected, Subject);
             }
 
             var expectedKeys = expectedKeyValuePairs.Select(keyValuePair => keyValuePair.Key).ToArray();
@@ -590,7 +590,7 @@ namespace FluentAssertions.Collections
                 {
                     Execute.Assertion
                         .BecauseOf(because, reasonArgs)
-                        .FailWith("Expected {context:dictionary} {0} to contain key(s) {1}{reason}, but could not find {2}.", Subject,
+                        .FailWith("Expected {context:dictionary} {0} to contain key(s) {1}{reason}, but could not find keys {2}.", Subject,
                             expectedKeys, missingKeys);
                 }
                 else
@@ -606,7 +606,7 @@ namespace FluentAssertions.Collections
 
             if (keyValuePairsNotSameOrEqualInSubject.Any())
             {
-                if (expectedKeys.Count() > 1)
+                if (keyValuePairsNotSameOrEqualInSubject.Count() > 1)
                 {
                     Execute.Assertion
                         .BecauseOf(because, reasonArgs)
@@ -615,7 +615,7 @@ namespace FluentAssertions.Collections
                 }
                 else
                 {
-                    var expectedKeyValuePair = expectedKeyValuePairs.First();
+                    var expectedKeyValuePair = keyValuePairsNotSameOrEqualInSubject.First();
                     TValue actual = Subject[expectedKeyValuePair.Key];
 
                     Execute.Assertion
@@ -717,14 +717,14 @@ namespace FluentAssertions.Collections
 
             if (!keyValuePairs.Any())
             {
-                throw new ArgumentException("Cannot verify key containment against an empty dictionary");
+                throw new ArgumentException("Cannot verify key containment against an empty collection of key/value pairs");
             }
 
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
                     .BecauseOf(because, reasonArgs)
-                    .FailWith("Expected {context:dictionary} not to contain key/value pairs {0}{reason}, but dictionary is {1}.", items, Subject);
+                    .FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but dictionary is {1}.", items, Subject);
             }
 
             var keyValuePairsFound = keyValuePairs.Where(keyValuePair => Subject.ContainsKey(keyValuePair.Key)).ToArray();
@@ -747,7 +747,7 @@ namespace FluentAssertions.Collections
                         
                         Execute.Assertion
                             .BecauseOf(because, reasonArgs)
-                            .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.", keyValuePair.Value, keyValuePair.Key);
+                            .FailWith("Expected {context:dictionary} to not contain value {0} at key {1}{reason}, but found it anyhow.", keyValuePair.Value, keyValuePair.Key);
                     }
                 }
             }

--- a/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -1210,6 +1210,442 @@ namespace FluentAssertions.Specs
         #region Contain
 
         [TestMethod]
+        public void Should_succeed_when_asserting_dictionary_contains_single_key_value_pair()
+        {
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One")
+            };
+
+            dictionary.Should().Contain(keyValuePairs);
+        }
+
+        [TestMethod]
+        public void Should_succeed_when_asserting_dictionary_does_not_contain_single_key_value_pair()
+        {
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(3, "Three")
+            };
+
+            dictionary.Should().NotContain(keyValuePairs);
+        }
+
+        [TestMethod]
+        public void Should_succeed_when_asserting_dictionary_does_not_contain_single_key_value_pair_with_existing_key_but_different_value()
+        {
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "Two")
+            };
+
+            dictionary.Should().NotContain(keyValuePairs);
+        }
+
+        [TestMethod]
+        public void Should_succeed_when_asserting_dictionary_contains_multiple_key_value_pairs()
+        {
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(2, "Two")
+            };
+
+            dictionary.Should().Contain(keyValuePairs);
+        }
+
+        [TestMethod]
+        public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_key_value_pairs()
+        {
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(3, "Three"),
+                new KeyValuePair<int, string>(4, "Four")
+            };
+
+            dictionary.Should().NotContain(keyValuePairs);
+        }
+
+        [TestMethod]
+        public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_key_value_pairs_with_existing_keys_but_different_values()
+        {
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "Three"),
+                new KeyValuePair<int, string>(2, "Four")
+            };
+
+            dictionary.Should().NotContain(keyValuePairs);
+        }
+
+        [TestMethod]
+        public void When_a_dictionary_does_not_contain_single_value_for_key_value_pairs_it_should_throw_with_clear_explanation()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(2, "Three")
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary to contain value \"Three\" at key 2 because we do, but found \"Two\".");
+        }
+
+        [TestMethod]
+        public void When_a_dictionary_does_not_contain_multiple_values_for_key_value_pairs_it_should_throw_with_clear_explanation()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "Two"),
+                new KeyValuePair<int, string>(2, "Three")
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary to contain {[1, Two], [2, Three]} because we do, but dictionary differs at keys {1, 2}.");
+        }
+
+        [TestMethod]
+        public void When_a_dictionary_does_not_contain_single_key_for_key_value_pairs_it_should_throw_with_clear_explanation()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(3, "Three")
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary {[1, One], [2, Two]} to contain key 3 because we do.");
+        }
+
+        [TestMethod]
+        public void When_a_dictionary_does_not_contain_multiple_keys_for_key_value_pairs_it_should_throw_with_clear_explanation()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(3, "Three"),
+                new KeyValuePair<int, string>(4, "Four"),
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary {[1, One], [2, Two]} to contain key(s) {1, 3, 4} because we do, but could not find keys {3, 4}.");
+        }
+
+        [TestMethod]
+        public void When_a_dictionary_does_contain_single_key_value_pair_it_should_throw_with_clear_explanation()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One")
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().NotContain(keyValuePairs, "because {0}", "we do");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary to not contain value \"One\" at key 1 because we do, but found it anyhow.");
+        }
+
+        [TestMethod]
+        public void When_a_dictionary_does_contain_multiple_key_value_pairs_it_should_throw_with_clear_explanation()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(2, "Two")
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().NotContain(keyValuePairs, "because {0}", "we do");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary to not contain key/value pairs {[1, One], [2, Two]} because we do, but found them anyhow.");
+        }
+
+        [TestMethod]
+        public void When_asserting_dictionary_contains_key_value_pairs_against_null_dictionary_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Dictionary<int, string> dictionary = null;
+            List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(1, "Two"),
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().Contain(keyValuePairs,
+                "because we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary to contain key/value pairs {[1, One], [1, Two]} because we want to test the behaviour with a null subject, but dictionary is <null>.");
+        }
+
+        [TestMethod]
+        public void When_asserting_dictionary_contains_key_value_pairs_but_expected_key_value_pairs_are_empty_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary1 = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+            List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary1.Should().Contain(keyValuePairs, "because we want to test the behaviour with an empty set of key/value pairs");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<ArgumentException>().WithMessage(
+                "Cannot verify key containment against an empty collection of key/value pairs");
+        }
+
+        [TestMethod]
+        public void When_asserting_dictionary_contains_key_value_pairs_but_expected_key_value_pairs_are_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary1 = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+            List<KeyValuePair<int, string>> keyValuePairs = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary1.Should().Contain(keyValuePairs, "because we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<ArgumentNullException>().WithMessage(
+                "Cannot compare dictionary with <null>.\r\nParameter name: expected");
+        }
+
+        [TestMethod]
+        public void When_asserting_dictionary_does_not_contain_key_value_pairs_against_null_dictionary_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Dictionary<int, string> dictionary = null;
+            List<KeyValuePair<int, string>> keyValuePairs = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(1, "Two"),
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().NotContain(keyValuePairs,
+                "because we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary to not contain key/value pairs {[1, One], [1, Two]} because we want to test the behaviour with a null subject, but dictionary is <null>.");
+        }
+
+        [TestMethod]
+        public void When_asserting_dictionary_does_not_contain_key_value_pairs_but_expected_key_value_pairs_are_empty_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary1 = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+            List<KeyValuePair<int, string>> keyValuePair = new List<KeyValuePair<int, string>>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary1.Should().NotContain(keyValuePair, "because we want to test the behaviour with an empty set of key/value pairs");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<ArgumentException>().WithMessage(
+                "Cannot verify key containment against an empty collection of key/value pairs");
+        }
+
+        [TestMethod]
+        public void When_asserting_dictionary_does_not_contain_key_value_pairs_but_expected_key_value_pairs_are_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary1 = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+            List<KeyValuePair<int, string>> keyValuePairs = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary1.Should().NotContain(keyValuePairs, "because we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<ArgumentNullException>().WithMessage(
+                "Cannot compare dictionary with <null>.\r\nParameter name: items");
+        }
+
+        [TestMethod]
         public void When_dictionary_contains_expected_value_at_specific_key_it_should_not_throw()
         {
             //-----------------------------------------------------------------------------------------------------------

--- a/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -1245,6 +1245,29 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void When_dictionary_contains_expected_key_value_pairs_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            var items = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(2, "Two")
+            };
+            dictionary.Should().Contain(items);
+        }
+
+        [TestMethod]
         public void When_dictionary_contains_expected_key_value_pair_it_should_not_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -1286,6 +1309,36 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
                 "Expected dictionary to contain value \"Two\" at key 1 because we put it there, but found \"One\".");
+        }
+
+        [TestMethod]
+        public void When_dictionary_does_not_contain_the_key_value_pairs_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var items = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "Two"),
+                new KeyValuePair<int, string>(2, "Three"),
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().Contain(items, "we put them {0}", "there");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary to contain {[1, Two], [2, Three]} because we put them there, but dictionary differs at keys {1, 2}.");
         }
 
         [TestMethod]
@@ -1416,6 +1469,29 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void When_dictionary_does_not_contain_unexpected_key_value_pairs_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            var items = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(3, "Three"),
+                new KeyValuePair<int, string>(4, "Four")
+            };
+            dictionary.Should().NotContain(items);
+        }
+
+        [TestMethod]
         public void When_dictionary_does_not_contain_unexpected_key_value_pair_it_should_not_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -1457,6 +1533,35 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
                 "Expected dictionary not to contain value \"One\" at key 1 because we put it there, but found it anyhow.");
+        }
+
+        [TestMethod]
+        public void When_dictionary_contains_the_key_value_pairs_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            var items = new List<KeyValuePair<int, string>>()
+            {
+                new KeyValuePair<int, string>(1, "One"),
+                new KeyValuePair<int, string>(2, "Two")
+            };
+            Action act = () => dictionary.Should().NotContain(items, "we did not put them {0}", "there");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary to not contain key/value pairs {[1, One], [2, Two]} because we did not put them there, but found them anyhow.");
         }
 
         [TestMethod]


### PR DESCRIPTION
The GenericDictionaryAssertions.cs file already contained .Contain() and .NotContain() methods that took a single KeyValuePair < TKey, TValue > but I am current writing tests against a custom IDictionary implementation and wanted to check more fluently whether more than one KeyValuePair is or is not in a given Dictionary.. so I figured why not adding it to FluentAssertions :)

Besides the two Assertion methods themselves, I took the existing tests targeting the single-key/value pair methods and used them as base for the added tests.

Cheers,
-Jörg