### PR TITLE
Xml node assertions

### DIFF
--- a/Src/Core/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/Core/Primitives/ReferenceTypeAssertions.cs
@@ -75,7 +75,7 @@ namespace FluentAssertions.Primitives
                 .UsingLineBreaks
                 .ForCondition(ReferenceEquals(Subject, expected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:object} to refer to {0}{reason}, but found object {1}.", expected, Subject);
+                .FailWith("Expected {context:" + Context + "} to refer to {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions.Net40/Common/ProvidePlatformServices.cs
+++ b/Src/FluentAssertions.Net40/Common/ProvidePlatformServices.cs
@@ -2,6 +2,7 @@
 
 using FluentAssertions.Execution;
 using FluentAssertions.Formatting;
+using FluentAssertions.Xml;
 
 namespace FluentAssertions.Common
 {
@@ -31,7 +32,8 @@ namespace FluentAssertions.Common
                     new AggregateExceptionValueFormatter(),
                     new XDocumentValueFormatter(),
                     new XElementValueFormatter(),
-                    new XAttributeValueFormatter()
+                    new XAttributeValueFormatter(),
+                    new XmlNodeFormatter()
                 };
             }
         }

--- a/Src/FluentAssertions.Net40/Net40.csproj
+++ b/Src/FluentAssertions.Net40/Net40.csproj
@@ -80,6 +80,10 @@
     <Compile Include="Execution\XUnitTestFramework.cs" />
     <Compile Include="ObjectAssertionsExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Xml\XmlAssertionExtensions.cs" />
+    <Compile Include="Xml\XmlNodeAssertions.cs" />
+    <Compile Include="Xml\XmlNodeFormatter.cs" />
+    <Compile Include="Xml\XmlReaderValidator.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\FluentAssertions.snk">

--- a/Src/FluentAssertions.Net40/Xml/XmlAssertionExtensions.cs
+++ b/Src/FluentAssertions.Net40/Xml/XmlAssertionExtensions.cs
@@ -1,0 +1,20 @@
+﻿using FluentAssertions.Xml;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace FluentAssertions
+{
+    [DebuggerNonUserCode]
+    public static class XmlAssertionExtensions
+    {
+        public static XmlNodeAssertions Should(this XmlNode actualValue)
+        {
+            return new XmlNodeAssertions(actualValue);
+        }
+    }
+}

--- a/Src/FluentAssertions.Net40/Xml/XmlNodeAssertions.cs
+++ b/Src/FluentAssertions.Net40/Xml/XmlNodeAssertions.cs
@@ -1,0 +1,95 @@
+﻿using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Xml;
+
+namespace FluentAssertions.Xml
+{
+    /// <summary>
+    /// Contains a number of methods to assert that an <see cref="XmlNode"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class XmlNodeAssertions : ReferenceTypeAssertions<XmlNode, XmlNodeAssertions>
+    {
+        public XmlNodeAssertions(XmlNode xmlNode)
+        {
+            Subject = xmlNode;
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlNode"/> is equivalent to the <paramref name="expected"/> element.
+        /// </summary>
+        /// <param name="expected">The expected element</param>
+        public AndConstraint<XmlNodeAssertions> BeEquivalentTo(XmlNode expected)
+        {
+            return BeEquivalentTo(expected, string.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlNode"/> is equivalent to the <paramref name="expected"/> node.
+        /// </summary>
+        /// <param name="expected">The expected node</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="reasonArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<XmlNodeAssertions> BeEquivalentTo(XmlNode expected, string because, params object[] reasonArgs)
+        {
+            using (XmlNodeReader subjectReader = new XmlNodeReader(Subject))
+            using (XmlNodeReader expectedReader = new XmlNodeReader(expected))
+            {
+                new XmlReaderValidator(subjectReader, expectedReader, because, reasonArgs).Validate(true);
+            }
+
+            return new AndConstraint<XmlNodeAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlNode"/> is not equivalent to
+        /// the <paramref name="unexpected"/> node.
+        /// </summary>
+        /// <param name="unexpected">The unexpected node</param>
+        public AndConstraint<XmlNodeAssertions> NotBeEquivalentTo(XmlNode unexpected)
+        {
+            return NotBeEquivalentTo(unexpected, string.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlNode"/> is not equivalent to
+        /// the <paramref name="unexpected"/> node.
+        /// </summary>
+        /// <param name="unexpected">The unexpected node</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="reasonArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        /// <returns></returns>
+        public AndConstraint<XmlNodeAssertions> NotBeEquivalentTo(XmlNode unexpected, string because, params object[] reasonArgs)
+        {
+            using (XmlNodeReader subjectReader = new XmlNodeReader(Subject))
+            using (XmlNodeReader unexpectedReader = new XmlNodeReader(unexpected))
+            {
+                new XmlReaderValidator(subjectReader, unexpectedReader, because, reasonArgs).Validate(false);
+            }
+
+            return new AndConstraint<XmlNodeAssertions>(this);
+        }
+
+        /// <summary>
+        /// Returns the type of the subject the assertion applies on.
+        /// </summary>
+        protected override string Context
+        {
+            get { return "Xml Node"; }
+        }
+    }
+}

--- a/Src/FluentAssertions.Net40/Xml/XmlNodeFormatter.cs
+++ b/Src/FluentAssertions.Net40/Xml/XmlNodeFormatter.cs
@@ -1,0 +1,33 @@
+﻿using FluentAssertions.Common;
+using FluentAssertions.Formatting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace FluentAssertions.Xml
+{
+    public class XmlNodeFormatter : IValueFormatter
+    {
+        public bool CanHandle(object value)
+        {
+            return value is XmlNode;
+        }
+
+        public string ToString(object value, bool useLineBreaks, IList<object> processedObjects = null, int nestedPropertyLevel = 0)
+        {
+            string outerXml = ((XmlNode)value).OuterXml;
+
+            int maxLength = 20;
+
+            if(outerXml.Length > maxLength)
+            {
+                outerXml = outerXml.Substring(0, maxLength).TrimEnd() + "...";
+            }
+
+            return outerXml.Escape(escapePlaceholders: true);
+        }
+    }
+}

--- a/Src/FluentAssertions.Net40/Xml/XmlReaderValidator.cs
+++ b/Src/FluentAssertions.Net40/Xml/XmlReaderValidator.cs
@@ -1,0 +1,239 @@
+﻿using FluentAssertions.Execution;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace FluentAssertions.Xml
+{
+    internal class XmlReaderValidator
+    {
+        AssertionScope assertion;
+        XmlReader subjectReader, otherReader;
+
+        string CurrentLocation
+        {
+            get { return "/" + string.Join("/", locationStack.Reverse()); }
+        }
+
+        Stack<string> locationStack = new Stack<string>();
+
+        public XmlReaderValidator(XmlReader subjectReader, XmlReader otherReader, string because, object[] reasonArgs)
+        {
+            assertion = Execute.Assertion.BecauseOf(because, reasonArgs);
+        
+            this.subjectReader = subjectReader;
+            this.otherReader = otherReader;
+        }
+                
+        class ValidationResult
+        {
+            public ValidationResult(string formatString, params object[] formatParams)
+            {
+                FormatString = formatString;
+                FormatParams = formatParams;
+            }
+
+            public string FormatString { get; }
+
+            public object[] FormatParams { get; }
+        }
+
+        public void Validate(bool expectedEquivalence)
+        {
+            ValidationResult validationResult = Validate();
+
+            if(expectedEquivalence && validationResult != null)
+            {
+                assertion.FailWith(validationResult.FormatString, validationResult.FormatParams);
+            }
+            if(!expectedEquivalence && validationResult == null)
+            {
+                assertion.FailWith("Expected Xml to not be equivalent{reason}, but it is.");
+            }
+        }
+
+        private ValidationResult Validate()
+        {
+            subjectReader.MoveToContent();
+            otherReader.MoveToContent();
+            while (!subjectReader.EOF && !otherReader.EOF)
+            {
+                if (subjectReader.NodeType != otherReader.NodeType)
+                {
+                    return new ValidationResult("Expected node of type {0} at {1}{reason}, but found {2}.",
+                        otherReader.NodeType, CurrentLocation, subjectReader.NodeType);
+                }
+
+                ValidationResult validationResult = null;
+
+                switch (subjectReader.NodeType)
+                {
+                    case XmlNodeType.Element:
+                        validationResult = ValidateStartElement();
+                        if(validationResult != null)
+                        {
+                            return validationResult;
+                        }
+                        locationStack.Push(subjectReader.LocalName);
+                        validationResult = ValidateAttributes();
+                        break;
+                    case XmlNodeType.EndElement:
+                        // No need to verify end element, if it doesn't match
+                        // the start element it isn't valid XML, so the parser
+                        // would handle that.
+                        locationStack.Pop();
+                        break;
+                    case XmlNodeType.Text:
+                        validationResult = ValidateText();
+                        break;
+                    default:
+                        throw new NotSupportedException($"{subjectReader.NodeType} found at {CurrentLocation} is not supported for equivalency comparison.");
+                }
+
+                if(validationResult != null)
+                {
+                    return validationResult;
+                }
+
+                subjectReader.Read();
+                otherReader.Read();
+
+                subjectReader.MoveToContent();
+                otherReader.MoveToContent();
+            }
+
+            if (!otherReader.EOF)
+            {
+                return new ValidationResult("Expected {0}{reason}, but found end of document.",
+                    otherReader.LocalName);
+            }
+
+            if (!subjectReader.EOF)
+            {
+                return new ValidationResult("Expected end of document{reason}, but found {0}.",
+                    subjectReader.LocalName);
+            }
+
+            return null;
+        }
+
+
+        class AttributeData
+        {
+            public AttributeData(string namespaceUri, string localName, string value, string prefix)
+            {
+                NamespaceUri = namespaceUri;
+                LocalName = localName;
+                Value = value;
+                Prefix = prefix;
+            }
+
+            public string NamespaceUri { get; }
+            public string LocalName { get; }
+            public string Value { get; }
+            public string Prefix { get; }
+
+            public string QualifiedName
+            {
+                get
+                {
+                    if(string.IsNullOrEmpty(Prefix))
+                    {
+                        return LocalName;
+                    }
+
+                    return Prefix + ":" + LocalName;
+                }
+            }
+        }
+
+        private ValidationResult ValidateAttributes()
+        {
+            IList<AttributeData> expectedAttributes = GetAttributes(otherReader);
+            IList<AttributeData> subjectAttributes = GetAttributes(subjectReader);
+
+            foreach (AttributeData subjectAttribute in subjectAttributes)
+            {
+                AttributeData expectedAttribute = expectedAttributes.SingleOrDefault(
+                    ea => ea.NamespaceUri == subjectAttribute.NamespaceUri
+                    && ea.LocalName == subjectAttribute.LocalName);
+
+                if (expectedAttribute == null)
+                {
+                    return new ValidationResult("Didn't expect to find attribute {0} at {1}{reason}.",
+                        subjectAttribute.QualifiedName, CurrentLocation);
+                }
+
+                if (subjectAttribute.Value != expectedAttribute.Value)
+                {
+                    return new ValidationResult("Expected attribute {0} at {1} to have value {2}{reason}, but found {3}.",
+                        subjectAttribute.LocalName, CurrentLocation, expectedAttribute.Value, subjectAttribute.Value);
+                }
+            }
+
+            if (subjectAttributes.Count != expectedAttributes.Count)
+            {
+                AttributeData missingAttribute = expectedAttributes.First(ea =>
+                    !subjectAttributes.Any(sa =>
+                        ea.NamespaceUri == sa.NamespaceUri
+                        && sa.LocalName == ea.LocalName));
+
+                return new ValidationResult("Expected attribute {0} at {1}{reason}, but found none.",
+                    missingAttribute.LocalName, CurrentLocation);
+            }
+            return null;
+        }
+
+        private IList<AttributeData> GetAttributes(XmlReader reader)
+        {
+            IList<AttributeData> attributes = new List<AttributeData>();
+
+            if (reader.MoveToFirstAttribute())
+            {
+                do
+                {
+                    if (reader.NamespaceURI != "http://www.w3.org/2000/xmlns/")
+                    {
+                        attributes.Add(new AttributeData(reader.NamespaceURI, reader.LocalName, reader.Value, reader.Prefix));
+                    }
+                } while (reader.MoveToNextAttribute());
+            }
+
+            return attributes;
+        }
+
+        private ValidationResult ValidateStartElement()
+        {
+            if (subjectReader.LocalName != otherReader.LocalName)
+            {
+                return new ValidationResult("Expected local name of element at {0} to be {1}{reason}, but found {2}.",
+                    CurrentLocation, otherReader.LocalName, subjectReader.LocalName);
+            }
+
+            if (subjectReader.NamespaceURI != otherReader.NamespaceURI)
+            {
+                return new ValidationResult("Expected namespace of element {0} at {1} to be {2}{reason}, but found {3}.",
+                    subjectReader.LocalName, CurrentLocation, otherReader.NamespaceURI, subjectReader.NamespaceURI);
+            }
+
+            return null;
+        }
+
+        private ValidationResult ValidateText()
+        {
+            string subject = subjectReader.Value;
+            string expected = otherReader.Value;
+
+            if (subject != expected)
+            {
+                return new ValidationResult("Expected content to be {0} at {1}{reason}, but found {2}.",
+                    expected, CurrentLocation, subject);
+            }
+
+            return null;
+        }
+    }
+}

--- a/Src/FluentAssertions.Net45/Net45.csproj
+++ b/Src/FluentAssertions.Net45/Net45.csproj
@@ -101,6 +101,18 @@
     <Compile Include="..\FluentAssertions.Net40\ObjectAssertionsExtensions.cs">
       <Link>ObjectAssertionsExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\FluentAssertions.Net40\Xml\XmlAssertionExtensions.cs">
+      <Link>Xml\XmlAssertionExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\FluentAssertions.Net40\Xml\XmlNodeAssertions.cs">
+      <Link>Xml\XmlNodeAssertions.cs</Link>
+    </Compile>
+    <Compile Include="..\FluentAssertions.Net40\Xml\XmlNodeFormatter.cs">
+      <Link>Xml\XmlNodeFormatter.cs</Link>
+    </Compile>
+    <Compile Include="..\FluentAssertions.Net40\Xml\XmlReaderValidator.cs">
+      <Link>Xml\XmlReaderValidator.cs</Link>
+    </Compile>
     <Compile Include="Execution\XUnit2TestFramework.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Tests/FluentAssertions.Net40.Specs/Net40.Specs.csproj
+++ b/Tests/FluentAssertions.Net40.Specs/Net40.Specs.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Chill\AutofacChillContainer.cs" />
     <Compile Include="Chill\DefaultChillContainer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="XmlNodeAssertionSpecs.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0">

--- a/Tests/FluentAssertions.Net40.Specs/XmlNodeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Net40.Specs/XmlNodeAssertionSpecs.cs
@@ -1,0 +1,554 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace FluentAssertions.Specs
+{
+    [TestClass]
+    public class XmlNodeAssertionSpecs
+    {
+        #region Be / NotBe
+
+        [TestMethod]
+        public void When_asserting_an_XmlNode_is_the_same_as_the_same_XmlNode_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var doc = new XmlDocument();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                doc.Should().BeSameAs(doc);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_same_as_a_different_XmlDocument_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var doc = new XmlDocument();
+            doc.LoadXml("<doc/>");
+            var otherNode = new XmlDocument();
+            otherNode.LoadXml("<otherDoc/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                doc.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected Xml Node to refer to <otherDoc /> because we want to test the failure message, but found <doc />.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_same_as_a_different_XmlDocument_it_should_fail_with_descriptive_message_and_truncate_xml()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var doc = new XmlDocument();
+            doc.LoadXml("<doc>Some very long text that should be truncated.</doc>");
+            var otherNode = new XmlDocument();
+            otherNode.LoadXml("<otherDoc/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                doc.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected Xml Node to refer to <otherDoc /> because we want to test the failure message, but found <doc>Some very long....");
+        }
+        #endregion
+
+        #region BeEquivalentTo / NotBeEquivalentTo
+
+        [TestMethod]
+        public void When_asserting_an_XmlNode_is_equivalent_as_the_same_XmlNode_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var doc = new XmlDocument();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                doc.Should().BeEquivalentTo(doc);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlNode_is_not_equivalent_to_som_other_XmlNode_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml>a</xml>");
+            var unexpected = new XmlDocument();
+            unexpected.LoadXml("<xml>b</xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().NotBeEquivalentTo(unexpected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlNode_is_not_equivalent_to_same_XmlNode_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml>a</xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().NotBeEquivalentTo(subject, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected Xml to not be equivalent because we want to test the failure message, but it is.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_a_different_XmlDocument_with_other_contents_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<subject/>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<expected/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected local name of element at \"/\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_a_different_XmlDocument_with_same_contents_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xml = "<root><a xmlns=\"urn:a\"><data>data</data></a><ns:b xmlns:ns=\"urn:b\"><data>data</data></ns:b></root>";
+
+            var subject = new XmlDocument();
+            subject.LoadXml(xml);
+            var expected = new XmlDocument();
+            expected.LoadXml(xml);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_assertion_an_XmlDocument_is_equivalent_to_a_different_XmlDocument_with_different_namespace_prefix_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml xmlns=\"urn:a\"/>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<a:xml xmlns:a=\"urn:a\"/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+        #endregion
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_a_different_XmlDocument_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml xmlns:a=\"urn:a\"/>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_a_different_XmlDcoument_which_differs_on_a_child_element_name_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml><child><subject/></child></xml>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml><child><expected/></child></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected local name of element at \"/xml/child\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_a_different_XmlDocument_which_differs_on_a_child_element_namespace_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<a:xml xmlns:a=\"urn:a\"><a:child><a:data/></a:child></a:xml>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml xmlns=\"urn:a\"><child><data xmlns=\"urn:b\"/></child></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected namespace of element \"data\" at \"/xml/child\" to be \"urn:b\" because we want to test the failure message, but found \"urn:a\".");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_contains_an_unexpected_node_type_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml>data</xml>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml><data/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected node of type Element at \"/xml\" because we want to test the failure message, but found Text.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_contains_extra_elements_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml><data/></xml>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected end of document because we want to test the failure message, but found \"data\".");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_lacks_elements_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml/>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml><data/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected \"data\" because we want to test the failure message, but found end of document.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_lacks_attributes_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml><element b=\"1\"/></xml>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml><element a=\"b\" b=\"1\"/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected attribute \"a\" at \"/xml/element\" because we want to test the failure message, but found none.");
+        }
+
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_has_extra_attributes_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml><element a=\"b\"/></xml>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml><element/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Didn't expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml><element a=\"b\"/></xml>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml><element a=\"c\"/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected attribute \"a\" at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml><element a=\"b\"/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Didn't expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_has_different_text_contents_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml>a</xml>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml>b</xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected content to be \"b\" at \"/xml\" because we want to test the failure message, but found \"a\".");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_with_different_comments_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml><!--Comment--><a/></xml>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml><a/><!--Comment--></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_with_different_insignificant_whitespace_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument() { PreserveWhitespace = true };
+            subject.LoadXml("<xml><a><b/></a></xml>");
+            var expected = new XmlDocument() { PreserveWhitespace = true };
+            expected.LoadXml("<xml>\n<a>   \n   <b/></a>\r\n</xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_XmlDocument_is_equivalent_that_contains_an_unsupported_node_it_should_throw_a_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument() { PreserveWhitespace = true };
+            subject.LoadXml("<xml><![CDATA[Text]]></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(subject);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<NotSupportedException>()
+                .WithMessage("CDATA found at /xml is not supported for equivalency comparison.");
+        }
+    }
+}

--- a/Tests/FluentAssertions.Net45.Specs/Net45.Specs.csproj
+++ b/Tests/FluentAssertions.Net45.Specs/Net45.Specs.csproj
@@ -84,6 +84,9 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="..\FluentAssertions.Net40.Specs\XmlNodeAssertionSpecs.cs">
+      <Link>XmlNodeAssertionSpecs.cs</Link>
+    </Compile>
     <Compile Include="AsyncFunctionExceptionAssertionSpecs.cs" />
     <Compile Include="Chill\AutofacChillContainer.cs" />
     <Compile Include="Chill\DefaultChillContainer.cs" />

--- a/Tests/FluentAssertions.Shared.Specs/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/ReferenceTypeAssertionsSpecs.cs
@@ -57,7 +57,7 @@ namespace FluentAssertions.Specs
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage(
                     "Expected object to refer to \r\n{ UserName = JohnDoe } because " +
-                    "they are the same, but found object \r\n{ Name = John Doe }.");
+                    "they are the same, but found \r\n{ Name = John Doe }.");
         }
 
         [TestMethod]


### PR DESCRIPTION
XmlDocument/XmlElement assertions as discussed in #354. 

Only available in .NET4.0 and .NET4.5 projects, as those are the only that appears to have XmlDocument support. The real comparison work is done in the XmlReaderValidator which I think only references stuff available on all platforms, so it should be possible to move to a shared library and reuse for XDocument/XElement comparisons (they can create an XmlReader too).

The comparison is done for each xml node in document order. A basic path to the current element is included in the error message to make it easier to track down where the difference is.

Example of assertion messages produced:
> Expected local name of element at "/xml/child" to be "expected" because we want to test the failure message, but found "subject".

> Expected local name of element at "/" to be "expected" because we want to test the failure message, but found "subject".

>Expected namespace of element "data" at "/xml/child" to be "urn:b" because we want to test the failure message, but found "urn:a".

Please comment on the approach before I've got too far. I'll continue working on the set up and get test coverage before asking for a merge.