### PR TITLE
Clean-up.

### DIFF
--- a/Src/Core/Collections/CollectionAssertions.cs
+++ b/Src/Core/Collections/CollectionAssertions.cs
@@ -22,13 +22,13 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeEmpty(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:collection} to be empty{reason}, ")
                 .ForCondition(!ReferenceEquals(Subject, null))
                 .FailWith("but found {0}.", Subject)
@@ -47,15 +47,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} not to be empty{reason}, but found {0}.", Subject);
             }
 
@@ -63,7 +63,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .ForCondition(enumerable.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} not to be empty{reason}.");
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -76,15 +76,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs)
         {
             var nullOrEmpty = ReferenceEquals(Subject, null) || !Subject.Cast<object>().Any();
 
             Execute.Assertion.ForCondition(nullOrEmpty)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:collection} to be null or empty{reason}, but found {0}.",
                     Subject);
@@ -99,13 +99,13 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs)
         {
-            return NotBeNull(because, reasonArgs)
-                .And.NotBeEmpty(because, reasonArgs);
+            return NotBeNull(because, becauseArgs)
+                .And.NotBeEmpty(because, becauseArgs);
         }
 
         /// <summary>
@@ -115,15 +115,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to only have unique items{reason}, but found {0}.", Subject);
             }
 
@@ -134,7 +134,7 @@ namespace FluentAssertions.Collections
             if (groupWithMultipleItems != null)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to only have unique items{reason}, but item {0} is not unique.",
                         groupWithMultipleItems.Key);
             }
@@ -149,15 +149,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} not to contain nulls{reason}, but collection is <null>.");
             }
 
@@ -167,7 +167,7 @@ namespace FluentAssertions.Collections
                 if (ReferenceEquals(values[index], null))
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:collection} not to contain nulls{reason}, but found one at index {0}.", index);
                 }
             }
@@ -194,18 +194,18 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> Equal(IEnumerable expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> Equal(IEnumerable expected, string because = "", params object[] becauseArgs)
         {
-            AssertSubjectEquality<object, object>(expected, (s, e) => s.IsSameOrEqualTo(e), because, reasonArgs);
+            AssertSubjectEquality<object, object>(expected, (s, e) => s.IsSameOrEqualTo(e), because, becauseArgs);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         protected void AssertSubjectEquality<TActual, TExpected>(IEnumerable expectation, Func<TActual, TExpected, bool> equalityComparison,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
 
             bool subjectIsNull = ReferenceEquals(Subject, null);
@@ -220,7 +220,7 @@ namespace FluentAssertions.Collections
                 throw new ArgumentNullException("expectation", "Cannot compare collection with <null>.");
             }
 
-            AssertionScope assertion = Execute.Assertion.BecauseOf(because, reasonArgs);
+            AssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs);
             if (subjectIsNull)
             {
                 assertion.FailWith("Expected {context:collection} to be equal{reason}, but found <null>.");
@@ -245,15 +245,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotEqual(IEnumerable unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> NotEqual(IEnumerable unexpected, string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected collections not to be equal{reason}, but found <null>.");
             }
 
@@ -267,7 +267,7 @@ namespace FluentAssertions.Collections
             if (actualitems.SequenceEqual(unexpected.Cast<object>()))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect collections {0} and {1} to be equal{reason}.", unexpected, Subject);
             }
 
@@ -293,10 +293,10 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeEquivalentTo(IEnumerable expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> BeEquivalentTo(IEnumerable expected, string because = "", params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -305,7 +305,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to be equivalent to {0}{reason}, but found <null>.", expected);
 
             List<object> expectedItems = expected.Cast<object>().ToList();
@@ -313,7 +313,7 @@ namespace FluentAssertions.Collections
 
             bool haveSameLength = Execute.Assertion
                 .ForCondition(actualItems.Count <= expectedItems.Count)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} {0} to be equivalent to {1}{reason}, but it contains too many items.",
                     actualItems, expectedItems);
 
@@ -323,14 +323,14 @@ namespace FluentAssertions.Collections
 
                 Execute.Assertion
                     .ForCondition(missingItems.Length == 0)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} {0} to be equivalent to {1}{reason}, but it misses {2}.",
                         actualItems, expectedItems, missingItems);
             }
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
-        public AndConstraint<TAssertions> BeEquivalentTo<T>(IEnumerable<T> expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> BeEquivalentTo<T>(IEnumerable<T> expected, string because = "", params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -339,7 +339,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to be equivalent to {0}{reason}, but found <null>.", expected);
 
             List<T> expectedItems = expected.ToList();
@@ -347,7 +347,7 @@ namespace FluentAssertions.Collections
 
             bool haveSameLength = Execute.Assertion
                 .ForCondition(actualItems.Count <= expectedItems.Count)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} {0} to be equivalent to {1}{reason}, but it contains too many items.",
                     actualItems, expectedItems);
 
@@ -357,7 +357,7 @@ namespace FluentAssertions.Collections
 
                 Execute.Assertion
                     .ForCondition(missingItems.Length == 0)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} {0} to be equivalent to {1}{reason}, but it misses {2}.",
                         actualItems, expectedItems, missingItems);
             }
@@ -373,11 +373,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> NotBeEquivalentTo(IEnumerable unexpected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (unexpected == null)
             {
@@ -387,7 +387,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} not to be equivalent{reason}, but found <null>.");
             }
 
@@ -400,7 +400,7 @@ namespace FluentAssertions.Collections
 
                 Execute.Assertion
                     .ForCondition(missingItems.Length > 0)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} {0} not be equivalent with collection {1}{reason}.", Subject,
                         unexpected);
             }
@@ -415,15 +415,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> ContainItemsAssignableTo<T>(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> ContainItemsAssignableTo<T>(string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain element assignable to type {0}{reason}, but found <null>.",
                         typeof(T));
             }
@@ -434,7 +434,7 @@ namespace FluentAssertions.Collections
                 if (!(item is T))
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith(
                             "Expected {context:collection} to contain only items of type {0}{reason}, but item {1} at index {2} is of type {3}.",
                             typeof(T), item, index, item.GetType());
@@ -478,10 +478,10 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> Contain(IEnumerable expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> Contain(IEnumerable expected, string because = "", params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -497,7 +497,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", expected);
             }
 
@@ -506,7 +506,7 @@ namespace FluentAssertions.Collections
                 if (!Subject.Cast<object>().Contains(expected))
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:collection} {0} to contain {1}{reason}.", Subject, expected);
                 }
             }
@@ -518,14 +518,14 @@ namespace FluentAssertions.Collections
                     if (expectedObjects.Count() > 1)
                     {
                         Execute.Assertion
-                            .BecauseOf(because, reasonArgs)
+                            .BecauseOf(because, becauseArgs)
                             .FailWith("Expected {context:collection} {0} to contain {1}{reason}, but could not find {2}.", Subject,
                                 expected, missingItems);
                     }
                     else
                     {
                         Execute.Assertion
-                            .BecauseOf(because, reasonArgs)
+                            .BecauseOf(because, becauseArgs)
                             .FailWith("Expected {context:collection} {0} to contain {1}{reason}.", Subject,
                                 expected.Cast<object>().First());
                     }
@@ -556,11 +556,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> ContainInOrder(IEnumerable expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -570,7 +570,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain {0} in order{reason}, but found <null>.", expected);
             }
 
@@ -588,7 +588,7 @@ namespace FluentAssertions.Collections
                 else
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith(
                             "Expected {context:collection} {0} to contain items {1} in order{reason}, but {2} (index {3}) did not appear (in the right order).",
                             Subject, expected, expectedItem, index);
@@ -606,12 +606,12 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeInAscendingOrder(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> BeInAscendingOrder(string because = "", params object[] becauseArgs)
         {
-            return BeInOrder(SortOrder.Ascending, because, reasonArgs);
+            return BeInOrder(SortOrder.Ascending, because, becauseArgs);
         }
 
         /// <summary>
@@ -622,26 +622,26 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeInDescendingOrder(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> BeInDescendingOrder(string because = "", params object[] becauseArgs)
         {
-            return BeInOrder(SortOrder.Descending, because, reasonArgs);
+            return BeInOrder(SortOrder.Descending, because, becauseArgs);
         }
 
         /// <summary>
         /// Expects the current collection to have all elements in the specified <paramref name="expectedOrder"/>.
         /// Elements are compared using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
-        private AndConstraint<TAssertions> BeInOrder(SortOrder expectedOrder, string because = "", params object[] reasonArgs)
+        private AndConstraint<TAssertions> BeInOrder(SortOrder expectedOrder, string because = "", params object[] becauseArgs)
         {
             string sortOrder = (expectedOrder == SortOrder.Ascending) ? "ascending" : "descending";
 
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain items in " + sortOrder + " order{reason}, but found {1}.",
                         Subject);
             }
@@ -656,7 +656,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .ForCondition(actualItems[index].IsSameOrEqualTo(orderedItems[index]))
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain items in " + sortOrder +
                               " order{reason}, but found {0} where item at index {1} is in wrong order.",
                         Subject, index);
@@ -673,12 +673,12 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotBeAscendingInOrder(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> NotBeAscendingInOrder(string because = "", params object[] becauseArgs)
         {
-            return NotBeInOrder(SortOrder.Ascending, because, reasonArgs);
+            return NotBeInOrder(SortOrder.Ascending, because, becauseArgs);
         }
 
         /// <summary>
@@ -689,26 +689,26 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotBeDescendingInOrder(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> NotBeDescendingInOrder(string because = "", params object[] becauseArgs)
         {
-            return NotBeInOrder(SortOrder.Descending, because, reasonArgs);
+            return NotBeInOrder(SortOrder.Descending, because, becauseArgs);
         }
 
         /// <summary>
         /// Asserts the current collection does not have all elements in ascending order. Elements are compared
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
-        private AndConstraint<TAssertions> NotBeInOrder(SortOrder order, string because = "", params object[] reasonArgs)
+        private AndConstraint<TAssertions> NotBeInOrder(SortOrder order, string because = "", params object[] becauseArgs)
         {
             string sortOrder = (order == SortOrder.Ascending) ? "ascending" : "descending";
 
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith(
                         "Did not expect {context:collection} to contain items in " + sortOrder + " order{reason}, but found {1}.",
                         Subject);
@@ -727,7 +727,7 @@ namespace FluentAssertions.Collections
             if (!itemsAreUnordered)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith(
                         "Did not expect {context:collection} to contain items in " + sortOrder + " order{reason}, but found {0}.",
                         Subject);
@@ -744,11 +744,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> BeSubsetOf(IEnumerable expectedSuperset, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (expectedSuperset == null)
             {
@@ -758,7 +758,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to be a subset of {0}{reason}, but found {1}.", expectedSuperset,
                         Subject);
             }
@@ -771,7 +771,7 @@ namespace FluentAssertions.Collections
             if (excessItems.Any())
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith(
                         "Expected {context:collection} to be a subset of {0}{reason}, but items {1} are not part of the superset.",
                         expectedSuperset, excessItems);
@@ -788,15 +788,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> NotBeSubsetOf(IEnumerable unexpectedSuperset, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Cannot assert a <null> collection against a subset.");
 
             IEnumerable<object> expectedItems = unexpectedSuperset.Cast<object>();
@@ -805,7 +805,7 @@ namespace FluentAssertions.Collections
             if (actualItems.Intersect(expectedItems).Count() == actualItems.Count())
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect {context:collection} {0} to be a subset of {1}{reason}.", actualItems, expectedItems);
             }
 
@@ -820,11 +820,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> HaveSameCount(IEnumerable otherCollection, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (otherCollection == null)
             {
@@ -834,7 +834,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to have the same count as {0}{reason}, but found {1}.",
                         otherCollection,
                         Subject);
@@ -847,7 +847,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .ForCondition(actualCount == expectedCount)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to have {0} item(s){reason}, but found {1}.", expectedCount, actualCount);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -863,16 +863,16 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndWhichConstraint<TAssertions, object> HaveElementAt(int index, object element, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to have element at index {0}{reason}, but found {1}.", index, Subject);
             }
 
@@ -885,13 +885,13 @@ namespace FluentAssertions.Collections
 
                 Execute.Assertion
                     .ForCondition(actual.IsSameOrEqualTo(element))
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {0} at index {1}{reason}, but found {2}.", element, index, actual);
             }
             else
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {0} at index {1}{reason}, but found no element.", element, index);
             }
 
@@ -906,15 +906,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} not to contain element {0}{reason}, but found {1}.", unexpected,
                         Subject);
             }
@@ -922,7 +922,7 @@ namespace FluentAssertions.Collections
             if (Subject.Cast<object>().Contains(unexpected))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("{context:Collection} {0} should not contain {1}{reason}, but found it anyhow.", Subject, unexpected);
             }
 
@@ -937,11 +937,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> IntersectWith(IEnumerable otherCollection, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (otherCollection == null)
             {
@@ -951,7 +951,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to intersect with {0}{reason}, but found {1}.", otherCollection,
                         Subject);
             }
@@ -962,7 +962,7 @@ namespace FluentAssertions.Collections
             if (!sharedItems.Any())
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith(
                         "Expected {context:collection} to intersect with {0}{reason}, but {1} does not contain any shared items.",
                         otherCollection, Subject);
@@ -979,11 +979,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> NotIntersectWith(IEnumerable otherCollection, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (otherCollection == null)
             {
@@ -993,7 +993,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect {context:collection} to intersect with {0}{reason}, but found {1}.", otherCollection,
                         Subject);
             }
@@ -1004,7 +1004,7 @@ namespace FluentAssertions.Collections
             if (sharedItems.Any())
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith(
                         "Did not expect {context:collection} to intersect with {0}{reason}, but found the following shared items {1}.",
                         otherCollection, sharedItems);
@@ -1033,10 +1033,10 @@ namespace FluentAssertions.Collections
             return new AndConstraint<TAssertions>((TAssertions) this);
         }
 
-        protected void AssertCollectionStartsWith<TActual, TExpected>(IEnumerable<TActual> actualItems, TExpected[] expected, Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] reasonArgs) 
+        protected void AssertCollectionStartsWith<TActual, TExpected>(IEnumerable<TActual> actualItems, TExpected[] expected, Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:collection} to start with {0}{reason}, ", expected)
                 .Given(() => actualItems)
                 .AssertCollectionIsNotNullOrEmpty()
@@ -1057,7 +1057,7 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> EndWith(object element, string because = "", params object[] becauseArgs)
@@ -1066,10 +1066,10 @@ namespace FluentAssertions.Collections
             return new AndConstraint<TAssertions>((TAssertions) this);
         }
 
-        protected void AssertCollectionEndsWith<TActual, TExpected>(IEnumerable<TActual> actual, TExpected[] expected, Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] reasonArgs)
+        protected void AssertCollectionEndsWith<TActual, TExpected>(IEnumerable<TActual> actual, TExpected[] expected, Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:collection} to end with {0}{reason}, ", expected)
                 .Given(() => actual)
                 .AssertCollectionIsNotNullOrEmpty()

--- a/Src/Core/Collections/GenericDictionaryAssertions.cs
+++ b/Src/Core/Collections/GenericDictionaryAssertions.cs
@@ -34,16 +34,16 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {0} item(s){reason}, but found {1}.", expected, Subject);
             }
 
@@ -51,7 +51,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .ForCondition((actualCount == expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} {0} to have {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
 
             return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
@@ -65,11 +65,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCount(Expression<Func<int, bool>> countPredicate,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             if (countPredicate == null)
             {
@@ -79,7 +79,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to have {0} items{reason}, but found {1}.", countPredicate.Body, Subject);
             }
 
@@ -90,7 +90,7 @@ namespace FluentAssertions.Collections
             if (!compiledPredicate(actualCount))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} {0} to have a count {1}{reason}, but count is {2}.",
                         Subject, countPredicate.Body, actualCount);
             }
@@ -109,21 +109,21 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] reasonArgs)
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to be empty{reason}, but found {0}.", Subject);
             }
 
             Execute.Assertion
                 .ForCondition(!Subject.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} to not have any items{reason}, but found {0}.", Subject.Count);
 
             return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
@@ -136,22 +136,22 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "",
-            params object [] reasonArgs)
+            params object [] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} not to be empty{reason}, but found {0}.", Subject);
             }
 
             Execute.Assertion
                 .ForCondition(Subject.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected one or more items{reason}, but found none.");
 
             return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
@@ -171,16 +171,16 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Equal(IDictionary<TKey, TValue> expected,
-            string because = "", params object [] reasonArgs)
+            string because = "", params object [] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but found {1}.", expected, Subject);
             }
 
@@ -195,7 +195,7 @@ namespace FluentAssertions.Collections
             if (missingKeys.Any())
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but could not find keys {1}.", expected,
                         missingKeys);
             }
@@ -203,7 +203,7 @@ namespace FluentAssertions.Collections
             if (additionalKeys.Any())
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but found additional keys {1}.", expected,
                         additionalKeys);
             }
@@ -212,7 +212,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .ForCondition(Subject[key].IsSameOrEqualTo(expected[key]))
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but {1} differs at key {2}.", 
                     expected, Subject, key);
             }
@@ -230,16 +230,16 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotEqual(IDictionary<TKey, TValue> unexpected,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected dictionaries not to be equal{reason}, but found {0}.", Subject);
             }
 
@@ -258,7 +258,7 @@ namespace FluentAssertions.Collections
             if (!foundDifference)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect dictionaries {0} and {1} to be equal{reason}.", unexpected, Subject);
             }
 
@@ -278,13 +278,13 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public WhichValueConstraint<TKey, TValue> ContainKey(TKey expected,
-            string because = "", params object [] reasonArgs)
+            string because = "", params object [] becauseArgs)
         {
-            AndConstraint<GenericDictionaryAssertions<TKey, TValue>> andConstraint = ContainKeys(new [] { expected }, because, reasonArgs);
+            AndConstraint<GenericDictionaryAssertions<TKey, TValue>> andConstraint = ContainKeys(new [] { expected }, because, becauseArgs);
 
             return new WhichValueConstraint<TKey, TValue>(andConstraint.And, Subject[expected]);
         }
@@ -308,11 +308,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> ContainKeys(IEnumerable<TKey> expected,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -329,7 +329,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to contain keys {0}{reason}, but found {1}.", expected, Subject);
             }
             
@@ -340,14 +340,14 @@ namespace FluentAssertions.Collections
                 if (expectedKeys.Count() > 1)
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}, but could not find {2}.", Subject,
                             expected, missingKeys);
                 }
                 else
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}.", Subject,
                             expected.Cast<object>().First());
                 }
@@ -369,23 +369,23 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} not to contain key {0}{reason}, but found {1}.", unexpected, Subject);
             }
 
             if (Subject.ContainsKey(unexpected))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("{context:Dictionary} {0} should not contain key {1}{reason}, but found it anyhow.", Subject, unexpected);
             }
 
@@ -405,14 +405,14 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndWhichConstraint<GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             AndWhichConstraint<GenericDictionaryAssertions<TKey, TValue>, IEnumerable<TValue>> innerConstraint =
-                    ContainValuesAndWhich(new[] {expected}, because, reasonArgs);
+                    ContainValuesAndWhich(new[] {expected}, because, becauseArgs);
 
             return
                 new AndWhichConstraint
@@ -439,17 +439,17 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> ContainValues(IEnumerable<TValue> expected,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
-            return ContainValuesAndWhich(expected, because, reasonArgs);
+            return ContainValuesAndWhich(expected, because, becauseArgs);
         }
 
         private AndWhichConstraint<GenericDictionaryAssertions<TKey, TValue>, IEnumerable<TValue>> ContainValuesAndWhich(IEnumerable<TValue> expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -466,7 +466,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to contain value {0}{reason}, but found {1}.", expected, Subject);
             }
 
@@ -476,14 +476,14 @@ namespace FluentAssertions.Collections
                 if (expectedValues.Count() > 1)
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:dictionary} {0} to contain value {1}{reason}, but could not find {2}.", Subject,
                             expected, missingValues);
                 }
                 else
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:dictionary} {0} to contain value {1}{reason}.", Subject,
                             expected.Cast<object>().First());
                 }
@@ -520,23 +520,23 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} not to contain value {0}{reason}, but found {1}.", unexpected, Subject);
             }
 
             if (Subject.Values.Contains(unexpected))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("{context:Dictionary} {0} should not contain value {1}{reason}, but found it anyhow.", Subject, unexpected);
             }
 
@@ -556,11 +556,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(IEnumerable<KeyValuePair<TKey, TValue>> expected,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -577,7 +577,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to contain key/value pairs {0}{reason}, but dictionary is {1}.", expected, Subject);
             }
 
@@ -589,14 +589,14 @@ namespace FluentAssertions.Collections
                 if (expectedKeyValuePairs.Count() > 1)
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:dictionary} {0} to contain key(s) {1}{reason}, but could not find keys {2}.", Subject,
                             expectedKeys, missingKeys);
                 }
                 else
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}.", Subject,
                             expectedKeys.Cast<object>().First());
                 }
@@ -609,7 +609,7 @@ namespace FluentAssertions.Collections
                 if (keyValuePairsNotSameOrEqualInSubject.Count() > 1)
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:dictionary} to contain {0}{reason}, but {context:dictionary} differs at keys {1}.",
                             expectedKeyValuePairs, keyValuePairsNotSameOrEqualInSubject.Select(keyValuePair => keyValuePair.Key));
                 }
@@ -619,7 +619,7 @@ namespace FluentAssertions.Collections
                     TValue actual = Subject[expectedKeyValuePair.Key];
 
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.", expectedKeyValuePair.Value, expectedKeyValuePair.Key, actual);
                 }
             }
@@ -636,13 +636,13 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(KeyValuePair<TKey, TValue> expected,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
-            return Contain(expected.Key, expected.Value, because, reasonArgs);
+            return Contain(expected.Key, expected.Value, because, becauseArgs);
         }
 
         /// <summary>
@@ -655,16 +655,16 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but dictionary is {2}.", value, key,
                         Subject);
             }
@@ -675,13 +675,13 @@ namespace FluentAssertions.Collections
 
                 Execute.Assertion
                     .ForCondition(actual.IsSameOrEqualTo(value))
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.", value, key, actual);
             }
             else
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but the key was not found.", value,
                         key);
             }
@@ -702,11 +702,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(IEnumerable<KeyValuePair<TKey, TValue>> items,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             if (items == null)
             {
@@ -723,7 +723,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but dictionary is {1}.", items, Subject);
             }
 
@@ -738,7 +738,7 @@ namespace FluentAssertions.Collections
                     if (keyValuePairsSameOrEqualInSubject.Count() > 1)
                     {
                         Execute.Assertion
-                            .BecauseOf(because, reasonArgs)
+                            .BecauseOf(because, becauseArgs)
                             .FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but found them anyhow.", keyValuePairs);
                     }
                     else
@@ -746,7 +746,7 @@ namespace FluentAssertions.Collections
                         var keyValuePair = keyValuePairsSameOrEqualInSubject.First();
                         
                         Execute.Assertion
-                            .BecauseOf(because, reasonArgs)
+                            .BecauseOf(because, becauseArgs)
                             .FailWith("Expected {context:dictionary} to not contain value {0} at key {1}{reason}, but found it anyhow.", keyValuePair.Value, keyValuePair.Key);
                     }
                 }
@@ -764,13 +764,13 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(KeyValuePair<TKey, TValue> item,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
-            return NotContain(item.Key, item.Value, because, reasonArgs);
+            return NotContain(item.Key, item.Value, because, becauseArgs);
         }
 
         /// <summary>
@@ -783,16 +783,16 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but dictionary is {2}.", value,
                         key, Subject);
             }
@@ -803,7 +803,7 @@ namespace FluentAssertions.Collections
 
                 Execute.Assertion
                     .ForCondition(!actual.IsSameOrEqualTo(value))
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.", value, key);
             }
 

--- a/Src/Core/Collections/NonGenericCollectionAssertions.cs
+++ b/Src/Core/Collections/NonGenericCollectionAssertions.cs
@@ -29,15 +29,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain {0} item(s){reason}, but found <null>.", expected);
             }
 
@@ -45,7 +45,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .ForCondition(actualCount == expected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to contain {0} item(s){reason}, but found {1}.", expected, actualCount);
 
             return new AndConstraint<NonGenericCollectionAssertions>(this);
@@ -59,11 +59,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<NonGenericCollectionAssertions> HaveCount(Expression<Func<int, bool>> countPredicate, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (countPredicate == null)
             {
@@ -73,7 +73,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain {0} items{reason}, but found {1}.", countPredicate.Body, Subject);
             }
 
@@ -84,7 +84,7 @@ namespace FluentAssertions.Collections
             if (!compiledPredicate(actualCount))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} {0} to have a count {1}{reason}, but count is {2}.",
                         Subject, countPredicate.Body, actualCount);
             }
@@ -114,18 +114,18 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<NonGenericCollectionAssertions> Contain(object expected, string because = "",
-            params object [] reasonArgs)
+            params object [] becauseArgs)
         {
             if (expected is IEnumerable)
             {
-                return base.Contain((IEnumerable) expected, because, reasonArgs);
+                return base.Contain((IEnumerable) expected, because, becauseArgs);
             }
 
-            return base.Contain(new [] { expected }, because, reasonArgs);
+            return base.Contain(new [] { expected }, because, becauseArgs);
         }
     }
 }

--- a/Src/Core/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/Core/Collections/SelfReferencingCollectionAssertions.cs
@@ -31,15 +31,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain {0} item(s){reason}, but found <null>.", expected);
             }
 
@@ -47,7 +47,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .ForCondition(actualCount == expected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to contain {0} item(s){reason}, but found {1}.", expected, actualCount);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -61,11 +61,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> HaveCount(Expression<Func<int, bool>> countPredicate, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (countPredicate == null)
             {
@@ -75,7 +75,7 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain {0} items{reason}, but found {1}.", countPredicate.Body, Subject);
             }
 
@@ -86,7 +86,7 @@ namespace FluentAssertions.Collections
             if (!compiledPredicate(actualCount))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} {0} to have a count {1}{reason}, but count is {2}.",
                         Subject, countPredicate.Body, actualCount);
             }
@@ -118,13 +118,13 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public AndConstraint<TAssertions> Equal<TExpected>(
-            IEnumerable<TExpected> expectation, Func<T, TExpected, bool> equalityComparison, string because = "", params object[] reasonArgs)
+            IEnumerable<TExpected> expectation, Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs)
         {
-            AssertSubjectEquality(expectation, equalityComparison, because, reasonArgs);
+            AssertSubjectEquality(expectation, equalityComparison, because, becauseArgs);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -140,17 +140,17 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> StartWith(IEnumerable<T> expectation, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> StartWith(IEnumerable<T> expectation, string because = "", params object[] becauseArgs)
         {
             if (expectation == null)
             {
-                return base.StartWith(null, because, reasonArgs);
+                return base.StartWith(null, because, becauseArgs);
             }
 
-            AssertCollectionStartsWith(Subject, expectation.ToArray(), EqualityComparer<T>.Default.Equals, because, reasonArgs);
+            AssertCollectionStartsWith(Subject, expectation.ToArray(), EqualityComparer<T>.Default.Equals, because, becauseArgs);
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
@@ -168,18 +168,18 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> StartWith<TExpected>(
-            IEnumerable<TExpected> expectation, Func<T, TExpected, bool> equalityComparison, string because = "", params object[] reasonArgs)
+            IEnumerable<TExpected> expectation, Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs)
         {
             if (expectation == null)
             {
                 throw new ArgumentNullException("expectation", "Cannot compare collection with <null>.");
             }
 
-            AssertCollectionStartsWith(Subject, expectation.ToArray(), equalityComparison, because, reasonArgs);
+            AssertCollectionStartsWith(Subject, expectation.ToArray(), equalityComparison, because, becauseArgs);
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
@@ -194,17 +194,17 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> EndWith(IEnumerable<T> expectation, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> EndWith(IEnumerable<T> expectation, string because = "", params object[] becauseArgs)
         {
             if (expectation == null)
             {
-                return base.EndWith(null, because, reasonArgs);
+                return base.EndWith(null, because, becauseArgs);
             }
 
-            AssertCollectionEndsWith(Subject, expectation.ToArray(), EqualityComparer<T>.Default.Equals, because, reasonArgs);
+            AssertCollectionEndsWith(Subject, expectation.ToArray(), EqualityComparer<T>.Default.Equals, because, becauseArgs);
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
@@ -222,18 +222,18 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> EndWith<TExpected>(
-            IEnumerable<TExpected> expectation, Func<T, TExpected, bool> equalityComparison, string because = "", params object[] reasonArgs)
+            IEnumerable<TExpected> expectation, Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs)
         {
             if (expectation == null)
             {
                 throw new ArgumentNullException("expectation", "Cannot compare collection with <null>.");
             }
 
-            AssertCollectionEndsWith(Subject, expectation.ToArray(), equalityComparison, because, reasonArgs);
+            AssertCollectionEndsWith(Subject, expectation.ToArray(), equalityComparison, because, becauseArgs);
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
@@ -245,22 +245,22 @@ namespace FluentAssertions.Collections
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] reasonArgs)
+        public AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain {0}{reason}, but found {1}.", expected, Subject);
             }
 
             if (!Subject.Contains(expected))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} {0} to contain {1}{reason}.", Subject, expected);
             }
 
@@ -291,15 +291,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public AndWhichConstraint<TAssertions, T> Contain(Expression<Func<T, bool>> predicate, string because = "", params object[] reasonArgs)
+        public AndWhichConstraint<TAssertions, T> Contain(Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain {0}{reason}, but found {1}.", predicate.Body, Subject);
             }
 
@@ -307,7 +307,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .ForCondition(Subject.Any(func))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("{context:Collection} {0} should have an item matching {1}{reason}.", Subject, predicate.Body);
 
             return new AndWhichConstraint<TAssertions, T>((TAssertions)this, Subject.Where(func));
@@ -321,17 +321,17 @@ namespace FluentAssertions.Collections
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         public AndConstraint<TAssertions> OnlyContain(
-            Expression<Func<T, bool>> predicate, string because = "", params object[] reasonArgs)
+            Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
         {
             Func<T, bool> compiledPredicate = predicate.Compile();
 
             Execute.Assertion
                 .ForCondition(Subject.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to contain only items matching {0}{reason}, but the collection is empty.",
                     predicate.Body);
             
@@ -339,7 +339,7 @@ namespace FluentAssertions.Collections
             if (mismatchingItems.Any())
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain only items matching {0}{reason}, but {1} do(es) not match.",
                         predicate.Body, mismatchingItems);
             }
@@ -355,22 +355,22 @@ namespace FluentAssertions.Collections
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public AndConstraint<TAssertions> NotContain(Expression<Func<T, bool>> predicate, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> NotContain(Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} not to contain {0}{reason}, but found {1}.", predicate.Body, Subject);
             }
 
             if (Subject.Any(item => predicate.Compile()(item)))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("{context:Collection} {0} should not have any items matching {1}{reason}.", Subject, predicate.Body);
             }
 
@@ -384,22 +384,22 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] reasonArgs)
+        public AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain a single item but found <null>.");
             }
 
             if (Subject.Count() != 1)
             {
                 Execute.Assertion
-                       .BecauseOf(because, reasonArgs)
+                       .BecauseOf(because, becauseArgs)
                        .FailWith("Expected {context:collection} to contain a single item.");
             }
 
@@ -414,11 +414,11 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndWhichConstraint<TAssertions, T> ContainSingle(Expression<Func<T, bool>> predicate,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             string expectationPrefix =
                 string.Format("Expected {{context:collection}} to contain a single item matching {0}{{reason}}, ", predicate.Body);
@@ -426,14 +426,14 @@ namespace FluentAssertions.Collections
             if (ReferenceEquals(Subject, null))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith(expectationPrefix + "but found {0}.", Subject);
             }
 
             T[] actualItems = Subject.ToArray();
             Execute.Assertion
                 .ForCondition(actualItems.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(expectationPrefix + "but the collection is empty.");
 
             T[] matchingElements = actualItems.Where(predicate.Compile()).ToArray();
@@ -441,13 +441,13 @@ namespace FluentAssertions.Collections
             if (count == 0)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith(expectationPrefix + "but no such item was found.");
             }
             else if (count > 1)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith(expectationPrefix + "but " + count + " such items were found.");
             }
             else

--- a/Src/Core/Collections/StringCollectionAssertions.cs
+++ b/Src/Core/Collections/StringCollectionAssertions.cs
@@ -16,13 +16,6 @@ namespace FluentAssertions.Collections
         /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.
         /// </summary>
         /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
         public new AndConstraint<StringCollectionAssertions> Equal(params string[] expected)
         {
             return base.Equal(expected.AsEnumerable());
@@ -33,13 +26,6 @@ namespace FluentAssertions.Collections
         /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.
         /// </summary>
         /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
         public AndConstraint<StringCollectionAssertions> Equal(IEnumerable<string> expected)
         {
             return base.Equal(expected);
@@ -64,13 +50,13 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<StringCollectionAssertions> BeEquivalentTo(IEnumerable<string> expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
-            return base.BeEquivalentTo(expected, because, reasonArgs);
+            return base.BeEquivalentTo(expected, because, becauseArgs);
         }
 
         /// <summary>
@@ -92,13 +78,13 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<StringCollectionAssertions> ContainInOrder(IEnumerable<string> expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
-            return base.ContainInOrder(expected, because, reasonArgs);
+            return base.ContainInOrder(expected, because, becauseArgs);
         }
 
         /// <summary>
@@ -106,13 +92,6 @@ namespace FluentAssertions.Collections
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
         /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
         public AndConstraint<StringCollectionAssertions> Contain(IEnumerable<string> expected)
         {
             return base.Contain(expected);
@@ -127,15 +106,15 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<StringCollectionAssertions> Contain(IEnumerable<string> expected, string because = null,
-            object reasonArg = null,
-            params object[] reasonArgs)
+            object becauseArg = null,
+            params object[] becauseArgs)
         {
-            var args = new List<object> {reasonArg};
-            args.AddRange(reasonArgs);
+            var args = new List<object> {becauseArg};
+            args.AddRange(becauseArgs);
             return base.Contain(expected, because, args.ToArray());
         }
     }

--- a/Src/Core/Equivalency/AssertionContext.cs
+++ b/Src/Core/Equivalency/AssertionContext.cs
@@ -5,20 +5,20 @@ namespace FluentAssertions.Equivalency
     internal class AssertionContext<TSubject> : IAssertionContext<TSubject>
     {
         public AssertionContext(SelectedMemberInfo subjectProperty, TSubject subject, TSubject expectation, string because,
-                                object[] reasonArgs)
+                                object[] becauseArgs)
         {
             SubjectProperty = subjectProperty;
             Subject = subject;
             Expectation = expectation;
-            Reason = because;
-            ReasonArgs = reasonArgs;
+            Because = because;
+            BecauseArgs = becauseArgs;
         }
 
         public SelectedMemberInfo SubjectProperty { get; private set; }
         public TSubject Subject { get; private set; }
         public TSubject Expectation { get; private set; }
-        public string Reason { get; set; }
-        public object[] ReasonArgs { get; set; }
+        public string Because { get; set; }
+        public object[] BecauseArgs { get; set; }
 
         internal static AssertionContext<TSubject> CreateFromEquivalencyValidationContext(IEquivalencyValidationContext context)
         {
@@ -28,8 +28,8 @@ namespace FluentAssertions.Equivalency
                 context.SelectedMemberInfo,
                 (TSubject)context.Subject,
                 expectation,
-                context.Reason,
-                context.ReasonArgs);
+                context.Because,
+                context.BecauseArgs);
             return assertionContext;
         }
     }

--- a/Src/Core/Equivalency/CollectionMemberAssertionRuleDecorator.cs
+++ b/Src/Core/Equivalency/CollectionMemberAssertionRuleDecorator.cs
@@ -33,8 +33,8 @@ namespace FluentAssertions.Equivalency
                 SelectedMemberDescription = context.SelectedMemberDescription,
                 SelectedMemberInfo = context.SelectedMemberInfo,
                 SelectedMemberPath = CollectionMemberSubjectInfo.GetAdjustedPropertyPath(context.SelectedMemberPath),
-                Reason = context.Reason,
-                ReasonArgs = context.ReasonArgs,
+                Because = context.Because,
+                BecauseArgs = context.BecauseArgs,
                 Subject = context.Subject
             };
         }

--- a/Src/Core/Equivalency/DictionaryEquivalencyStep.cs
+++ b/Src/Core/Equivalency/DictionaryEquivalencyStep.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions.Equivalency
                     }
                     else
                     {
-                        subject[key].Should().Be(expectation[key], context.Reason, context.ReasonArgs);
+                        subject[key].Should().Be(expectation[key], context.Because, context.BecauseArgs);
                     }
                 }
             }

--- a/Src/Core/Equivalency/EnumEqualityStep.cs
+++ b/Src/Core/Equivalency/EnumEqualityStep.cs
@@ -39,11 +39,11 @@ namespace FluentAssertions.Equivalency
                     long subjectsUnderlyingValue = Convert.ToInt64(context.Subject);
                     long expectationsUnderlyingValue = Convert.ToInt64(context.Expectation);
 
-                    subjectsUnderlyingValue.Should().Be(expectationsUnderlyingValue, context.Reason, context.ReasonArgs);
+                    subjectsUnderlyingValue.Should().Be(expectationsUnderlyingValue, context.Because, context.BecauseArgs);
                     break;
 
                 case EnumEquivalencyHandling.ByName:
-                    context.Subject.ToString().Should().Be(context.Expectation.ToString(), context.Reason, context.ReasonArgs);
+                    context.Subject.ToString().Should().Be(context.Expectation.ToString(), context.Because, context.BecauseArgs);
                     break;
 
                 default:

--- a/Src/Core/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/Core/Equivalency/EquivalencyValidationContext.cs
@@ -33,12 +33,12 @@ namespace FluentAssertions.Equivalency
         ///   A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         ///   is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </summary>
-        public string Reason { get; set; }
+        public string Because { get; set; }
 
         /// <summary>
-        ///   Zero or more objects to format using the placeholders in <see cref="IEquivalencyValidationContext.Reason" />.
+        ///   Zero or more objects to format using the placeholders in <see cref="IEquivalencyValidationContext.Because" />.
         /// </summary>
-        public object[] ReasonArgs { get; set; }
+        public object[] BecauseArgs { get; set; }
 
         /// <summary>
         ///   Gets a value indicating whether the current context represents the root of the object graph.

--- a/Src/Core/Equivalency/EquivalencyValidationContextExtentions.cs
+++ b/Src/Core/Equivalency/EquivalencyValidationContextExtentions.cs
@@ -18,8 +18,8 @@ namespace FluentAssertions.Equivalency
                 Expectation = matchingProperty.GetValue(context.Expectation, null),
                 SelectedMemberPath = context.SelectedMemberPath.Combine(memberDescription, "."),
                 SelectedMemberDescription = propertyPath + memberDescription,
-                Reason = context.Reason,
-                ReasonArgs = context.ReasonArgs,
+                Because = context.Because,
+                BecauseArgs = context.BecauseArgs,
                 CompileTimeType = nestedMember.MemberType,
                 RootIsCollection = context.RootIsCollection
             };
@@ -38,8 +38,8 @@ namespace FluentAssertions.Equivalency
                 Expectation = expectation,
                 SelectedMemberPath = context.SelectedMemberPath.Combine(memberDescription, String.Empty),
                 SelectedMemberDescription = propertyPath + memberDescription,
-                Reason = context.Reason,
-                ReasonArgs = context.ReasonArgs,
+                Because = context.Because,
+                BecauseArgs = context.BecauseArgs,
                 CompileTimeType = typeof (T),
                 RootIsCollection = context.RootIsCollection
             };
@@ -61,8 +61,8 @@ namespace FluentAssertions.Equivalency
                 Expectation = expectation,
                 SelectedMemberPath = context.SelectedMemberPath.Combine(memberDescription, String.Empty),
                 SelectedMemberDescription = propertyPath + memberDescription,
-                Reason = context.Reason,
-                ReasonArgs = context.ReasonArgs,
+                Because = context.Because,
+                BecauseArgs = context.BecauseArgs,
                 CompileTimeType = typeof (TValue),
                 RootIsCollection = context.RootIsCollection
             };
@@ -78,8 +78,8 @@ namespace FluentAssertions.Equivalency
                 SelectedMemberDescription = context.SelectedMemberDescription,
                 SelectedMemberInfo = context.SelectedMemberInfo,
                 SelectedMemberPath = context.SelectedMemberPath,
-                Reason = context.Reason,
-                ReasonArgs = context.ReasonArgs,
+                Because = context.Because,
+                BecauseArgs = context.BecauseArgs,
                 Subject = subject
             };
         }

--- a/Src/Core/Equivalency/EquivalencyValidator.cs
+++ b/Src/Core/Equivalency/EquivalencyValidator.cs
@@ -31,7 +31,7 @@ namespace FluentAssertions.Equivalency
                 scope.AddReportable("configuration", config.ToString());
                 scope.AddNonReportable("objects", new ObjectTracker(config.CyclicReferenceHandling));
 
-                scope.BecauseOf(context.Reason, context.ReasonArgs);
+                scope.BecauseOf(context.Because, context.BecauseArgs);
 
                 AssertEqualityUsing(context);
             }

--- a/Src/Core/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/Core/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -202,7 +202,7 @@ namespace FluentAssertions.Equivalency
                     }
                     else
                     {
-                        subject[key].Should().Be(expectation[key], context.Reason, context.ReasonArgs);
+                        subject[key].Should().Be(expectation[key], context.Because, context.BecauseArgs);
                     }
                 }
                 else

--- a/Src/Core/Equivalency/IAssertionContext.cs
+++ b/Src/Core/Equivalency/IAssertionContext.cs
@@ -26,11 +26,11 @@ namespace FluentAssertions.Equivalency
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </summary>
-        string Reason { get; set; }
+        string Because { get; set; }
 
         /// <summary>
-        /// Zero or more objects to format using the placeholders in <see cref="because"/>.
+        /// Zero or more objects to format using the placeholders in <see cref="Because"/>.
         /// </summary>
-        object[] ReasonArgs { get; set; }
+        object[] BecauseArgs { get; set; }
     }
 }

--- a/Src/Core/Equivalency/IEquivalencyValidationContext.cs
+++ b/Src/Core/Equivalency/IEquivalencyValidationContext.cs
@@ -14,12 +14,12 @@ namespace FluentAssertions.Equivalency
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </summary>
-        string Reason { get; }
+        string Because { get; }
 
         /// <summary>
-        /// Zero or more objects to format using the placeholders in <see cref="because"/>.
+        /// Zero or more objects to format using the placeholders in <see cref="Because"/>.
         /// </summary>
-        object[] ReasonArgs { get; }
+        object[] BecauseArgs { get; }
 
         /// <summary>
         /// Gets a value indicating whether the current context represents the root of the object graph.

--- a/Src/Core/Equivalency/SimpleEqualityEquivalencyStep.cs
+++ b/Src/Core/Equivalency/SimpleEqualityEquivalencyStep.cs
@@ -22,7 +22,7 @@ namespace FluentAssertions.Equivalency
         /// </remarks>
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator structuralEqualityValidator, IEquivalencyAssertionOptions config)
         {
-            context.Subject.Should().Be(context.Expectation, context.Reason, context.ReasonArgs);
+            context.Subject.Should().Be(context.Expectation, context.Because, context.BecauseArgs);
 
             return true;
         }

--- a/Src/Core/Equivalency/StringEqualityEquivalencyStep.cs
+++ b/Src/Core/Equivalency/StringEqualityEquivalencyStep.cs
@@ -44,7 +44,7 @@ namespace FluentAssertions.Equivalency
                     : (string) context.Expectation;
 
                 subject.Should()
-                    .Be(expectation, context.Reason, context.ReasonArgs);
+                    .Be(expectation, context.Because, context.BecauseArgs);
             }
 
             return true;

--- a/Src/Core/Equivalency/ValueTypeEquivalencyStep.cs
+++ b/Src/Core/Equivalency/ValueTypeEquivalencyStep.cs
@@ -33,7 +33,7 @@ namespace FluentAssertions.Equivalency
         /// </remarks>
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator structuralEqualityValidator, IEquivalencyAssertionOptions config)
         {
-            context.Subject.Should().Be(context.Expectation, context.Reason, context.ReasonArgs);
+            context.Subject.Should().Be(context.Expectation, context.Because, context.BecauseArgs);
 
             return true;
         }

--- a/Src/Core/Execution/AssertionScope.cs
+++ b/Src/Core/Execution/AssertionScope.cs
@@ -106,12 +106,12 @@ namespace FluentAssertions.Execution
         /// A formatted phrase explaining why the condition should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public AssertionScope BecauseOf(string because, params object[] reasonArgs)
+        public AssertionScope BecauseOf(string because, params object[] becauseArgs)
         {
-            reason = string.Format(because ?? "", reasonArgs ?? new object[0]);
+            reason = string.Format(because ?? "", becauseArgs ?? new object[0]);
             return this;
         } 
 

--- a/Src/Core/InternalAssertionExtensions.cs
+++ b/Src/Core/InternalAssertionExtensions.cs
@@ -387,13 +387,13 @@ namespace FluentAssertions
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the 
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public static void ShouldBeEquivalentTo<T>(this T subject, object expectation, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
-            ShouldBeEquivalentTo(subject, expectation, config => config, because, reasonArgs);
+            ShouldBeEquivalentTo(subject, expectation, config => config, because, becauseArgs);
         }
 
         /// <summary>
@@ -414,42 +414,42 @@ namespace FluentAssertions
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the 
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public static void ShouldBeEquivalentTo<T>(this T subject, object expectation,
             Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> config, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             var context = new EquivalencyValidationContext
             {
                 Subject = subject,
                 Expectation = expectation,
                 CompileTimeType = typeof(T),
-                Reason = because,
-                ReasonArgs = reasonArgs
+                Because = because,
+                BecauseArgs = becauseArgs
             };
 
             new EquivalencyValidator(config(AssertionOptions.CloneDefaults<T>())).AssertEquality(context);
         }
 
         public static void ShouldAllBeEquivalentTo<T>(this IEnumerable<T> subject, IEnumerable expectation,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
-            ShouldAllBeEquivalentTo(subject, expectation, config => config, because, reasonArgs);
+            ShouldAllBeEquivalentTo(subject, expectation, config => config, because, becauseArgs);
         }
 
         public static void ShouldAllBeEquivalentTo<T>(this IEnumerable<T> subject, IEnumerable expectation,
             Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> config, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             var context = new EquivalencyValidationContext()
             {
                 Subject = subject,
                 Expectation = expectation,
                 CompileTimeType = typeof(T),
-                Reason = because,
-                ReasonArgs = reasonArgs
+                Because = because,
+                BecauseArgs = becauseArgs
             };
 
             new EquivalencyValidator(config(AssertionOptions.CloneDefaults<T>())).AssertEquality(context);

--- a/Src/Core/Numeric/ComparableTypeAssertions.cs
+++ b/Src/Core/Numeric/ComparableTypeAssertions.cs
@@ -28,14 +28,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(ReferenceEquals(Subject, expected) || (Subject.CompareTo(expected) == Equal))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
@@ -51,14 +51,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> NotBe(T expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<ComparableTypeAssertions<T>> NotBe(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) != Equal)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect object to be equal to {0}{reason}.", expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
@@ -74,14 +74,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) < Equal)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected object {0} to be less than {1}{reason}.", Subject, expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
@@ -97,14 +97,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) <= Equal)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected object {0} to be less or equal to {1}{reason}.", Subject, expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
@@ -120,14 +120,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) > Equal)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected object {0} to be greater than {1}{reason}.", Subject, expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
@@ -143,14 +143,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) >= Equal)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected object {0} to be greater or equal to {1}{reason}.", Subject, expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
@@ -172,15 +172,15 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public AndConstraint<ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition((Subject.CompareTo(minimumValue) >= Equal) && (Subject.CompareTo(maximumValue) <= Equal))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected object to be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, Subject);
 

--- a/Src/Core/Numeric/NullableNumericAssertions.cs
+++ b/Src/Core/Numeric/NullableNumericAssertions.cs
@@ -17,14 +17,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>      
-        public AndConstraint<NullableNumericAssertions<T>> HaveValue(string because = "", params object[] reasonArgs)
+        public AndConstraint<NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value{reason}.");
 
             return new AndConstraint<NullableNumericAssertions<T>>(this);
@@ -37,14 +37,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>  
-        public AndConstraint<NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] reasonArgs) 
+        public AndConstraint<NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) 
         {
             Execute.Assertion
                 .ForCondition(ReferenceEquals(Subject, null))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect a value{reason}, but found {0}.", Subject);
 
             return new AndConstraint<NullableNumericAssertions<T>>(this);

--- a/Src/Core/Numeric/NumericAssertions.cs
+++ b/Src/Core/Numeric/NumericAssertions.cs
@@ -36,14 +36,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> Be(T expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(ReferenceEquals(Subject, expected) || ((!ReferenceEquals(Subject, null) && Subject.CompareTo(expected) == 0)))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -57,14 +57,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> Be(T? expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(ReferenceEquals(Subject, expected) || ((!ReferenceEquals(Subject, null) && Subject.CompareTo(expected) == 0)))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -78,14 +78,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(unexpected) != 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {0}{reason}.", unexpected);
 
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -99,14 +99,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(unexpected) != 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {0}{reason}.", unexpected);
 
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -119,14 +119,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BePositive(string because = "", params object[] reasonArgs)
+        public AndConstraint<NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(default(T)) > 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected positive value{reason}, but found {0}", Subject);
             
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -139,14 +139,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BeNegative(string because = "", params object[] reasonArgs)
+        public AndConstraint<NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(default(T)) < 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected negative value{reason}, but found {0}", Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -160,14 +160,14 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) < 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value less than {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -181,15 +181,15 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) <= 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value less or equal to {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -203,15 +203,15 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<NumericAssertions<T>> BeGreaterThan(T expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) > 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value greater than {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -225,15 +225,15 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) >= 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value greater or equal to {0}{reason}, but found {1}.", expected, Subject);
             
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -255,15 +255,15 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public AndConstraint<NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition((Subject.CompareTo(minimumValue) >= 0) && (Subject.CompareTo(maximumValue) <= 0))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected value to be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, Subject);
 
@@ -291,15 +291,15 @@ namespace FluentAssertions.Numeric
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public AndConstraint<NumericAssertions<T>> BeOneOf(IEnumerable<T> validValues, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(validValues.Contains((T)Subject))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected value to be one of {0}{reason}, but found {1}.", validValues, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);

--- a/Src/Core/NumericAssertionsExtensions.cs
+++ b/Src/Core/NumericAssertionsExtensions.cs
@@ -23,20 +23,20 @@ namespace FluentAssertions
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public static AndConstraint<NullableNumericAssertions<float>> BeApproximately(this NullableNumericAssertions<float> parent,
             float expectedValue, float precision, string because = "",
-            params object [] reasonArgs)
+            params object [] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected value to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
             var nonNullableAssertions = new NumericAssertions<float>((float) parent.Subject);
-            nonNullableAssertions.BeApproximately(expectedValue, precision, because, reasonArgs);
+            nonNullableAssertions.BeApproximately(expectedValue, precision, because, becauseArgs);
 
             return new AndConstraint<NullableNumericAssertions<float>>(parent);
         }
@@ -55,18 +55,18 @@ namespace FluentAssertions
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public static AndConstraint<NumericAssertions<float>> BeApproximately(this NumericAssertions<float> parent,
             float expectedValue, float precision, string because = "",
-            params object [] reasonArgs)
+            params object [] becauseArgs)
         {
             float actualDifference = Math.Abs(expectedValue - (float)parent.Subject);
             
             Execute.Assertion
                 .ForCondition(actualDifference <= precision)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected value {0} to approximate {1} +/- {2}{reason}, but it differed by {3}.",
                     parent.Subject, expectedValue, precision, actualDifference);
 
@@ -87,20 +87,20 @@ namespace FluentAssertions
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public static AndConstraint<NullableNumericAssertions<double>> BeApproximately(this NullableNumericAssertions<double> parent,
             double expectedValue, double precision, string because = "",
-            params object [] reasonArgs)
+            params object [] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected value to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
             var nonNullableAssertions = new NumericAssertions<double>((double) parent.Subject);
-            BeApproximately(nonNullableAssertions, expectedValue, precision, because, reasonArgs);
+            BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
 
             return new AndConstraint<NullableNumericAssertions<double>>(parent);
         }
@@ -119,18 +119,18 @@ namespace FluentAssertions
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public static AndConstraint<NumericAssertions<double>> BeApproximately(this NumericAssertions<double> parent,
             double expectedValue, double precision, string because = "",
-            params object [] reasonArgs)
+            params object [] becauseArgs)
         {
             double actualDifference = Math.Abs(expectedValue - (double) parent.Subject);
 
             Execute.Assertion
                 .ForCondition(actualDifference <= precision)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected value {0} to approximate {1} +/- {2}{reason}, but it differed by {3}.",
                     parent.Subject, expectedValue, precision, actualDifference);
 
@@ -151,20 +151,20 @@ namespace FluentAssertions
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public static AndConstraint<NullableNumericAssertions<decimal>> BeApproximately(this NullableNumericAssertions<decimal> parent,
             decimal expectedValue, decimal precision, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected value to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
             var nonNullableAssertions = new NumericAssertions<decimal>((decimal)parent.Subject);
-            BeApproximately(nonNullableAssertions, expectedValue, precision, because, reasonArgs);
+            BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
 
             return new AndConstraint<NullableNumericAssertions<decimal>>(parent);
         }
@@ -183,18 +183,18 @@ namespace FluentAssertions
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public static AndConstraint<NumericAssertions<decimal>> BeApproximately(this NumericAssertions<decimal> parent,
             decimal expectedValue, decimal precision, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             decimal actualDifference = Math.Abs(expectedValue - (decimal)parent.Subject);
 
             Execute.Assertion
                 .ForCondition(actualDifference <= precision)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected value {0} to approximate {1} +/- {2}{reason}, but it differed by {3}.",
                     parent.Subject, expectedValue, precision, actualDifference);
 

--- a/Src/Core/Primitives/BooleanAssertions.cs
+++ b/Src/Core/Primitives/BooleanAssertions.cs
@@ -27,14 +27,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> BeFalse(string because = "", params object[] reasonArgs)
+        public AndConstraint<BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && !Subject.Value)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", false, Subject);
 
             return new AndConstraint<BooleanAssertions>(this);
@@ -47,14 +47,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> BeTrue(string because = "", params object[] reasonArgs)
+        public AndConstraint<BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", true, Subject);
 
             return new AndConstraint<BooleanAssertions>(this);
@@ -68,14 +68,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> Be(bool expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.Equals(expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<BooleanAssertions>(this);

--- a/Src/Core/Primitives/DateTimeAssertions.cs
+++ b/Src/Core/Primitives/DateTimeAssertions.cs
@@ -31,14 +31,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> Be(DateTime expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeAssertions> Be(DateTime expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && (Subject.Value == expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
                     expected, Subject.HasValue ? Subject.Value : default(DateTime?));
 
@@ -53,15 +53,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeAssertions> NotBe(DateTime unexpected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:date and time} to be {0}{reason}.", unexpected);
 
             return new AndConstraint<DateTimeAssertions>(this);
@@ -85,11 +85,11 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeAssertions> BeCloseTo(DateTime nearbyTime, int precision = 20, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             long distanceToMinInMs = (long) (nearbyTime - DateTime.MinValue).TotalMilliseconds;
             DateTime minimumValue = nearbyTime.AddMilliseconds(-Math.Min(precision, distanceToMinInMs));
@@ -99,7 +99,7 @@ namespace FluentAssertions.Primitives
 
             Execute.Assertion
                 .ForCondition(Subject.HasValue && (Subject.Value >= minimumValue) && (Subject.Value <= maximumValue))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be within {0} ms from {1}{reason}, but found {2}.",
                     precision,
                     nearbyTime, Subject.HasValue ? Subject.Value : default(DateTime?));
@@ -115,15 +115,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeAssertions> BeBefore(DateTime expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a {context:date and time} before {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTime?));
 
@@ -138,15 +138,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeAssertions> BeOnOrBefore(DateTime expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a {context:date and time} on or before {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTime?));
 
@@ -161,15 +161,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeAssertions> BeAfter(DateTime expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a {context:date and time} after {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTime?));
 
@@ -184,15 +184,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeAssertions> BeOnOrAfter(DateTime expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a {context:date and time} on or after {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTime?));
 
@@ -207,21 +207,21 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveYear(int expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected year {0}{reason}, but found a <null> DateTime.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Year == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected year {0}{reason}, but found {1}.", expected,
                         Subject.Value.Year);
             }
@@ -237,21 +237,21 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected month {0}{reason}, but found a <null> DateTime.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Month == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected month {0}{reason}, but found {1}.", expected, Subject.Value.Month);
             }
             return new AndConstraint<DateTimeAssertions>(this);
@@ -265,21 +265,21 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveDay(int expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected day {0}{reason}, but found a <null> DateTime.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Day == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected day {0}{reason}, but found {1}.", expected, Subject.Value.Day);
             }
 
@@ -294,21 +294,21 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveHour(int expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected hour {0}{reason}, but found a <null> DateTime.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Hour == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected hour {0}{reason}, but found {1}.", expected, Subject.Value.Hour);
             }
 
@@ -323,22 +323,22 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeAssertions> HaveMinute(int expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected minute {0}{reason}, but found a <null> DateTime.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Minute == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected minute {0}{reason}, but found {1}.", expected, Subject.Value.Minute);
             }
 
@@ -353,22 +353,22 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeAssertions> HaveSecond(int expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected second {0}{reason}, but found a <null> DateTime.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Second == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected second {0}{reason}, but found {1}.", expected, Subject.Value.Second);
             }
 
@@ -444,21 +444,21 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeAssertions> BeSameDateAs(DateTime expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             var expectedDate = expected.Date;
 
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a {context:date and time} with date {0}{reason}, but found a <null> DateTime.", expectedDate)
                 .Then
                 .ForCondition(Subject.Value.Date == expectedDate)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a {context:date and time} with date {0}{reason}, but found {1}.", expectedDate, Subject.Value);
 
             return new AndConstraint<DateTimeAssertions>(this);

--- a/Src/Core/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/Core/Primitives/DateTimeOffsetAssertions.cs
@@ -31,15 +31,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> Be(DateTimeOffset expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && (Subject.Value == expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
                     expected, Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
 
@@ -54,15 +54,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> NotBe(DateTimeOffset unexpected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:date and time} to be {0}{reason}.", unexpected);
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
@@ -86,12 +86,12 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> BeCloseTo(DateTimeOffset nearbyTime, int precision = 20,
             string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             long distanceToMinInMs = (long)(nearbyTime - DateTimeOffset.MinValue).TotalMilliseconds;
             DateTimeOffset minimumValue = nearbyTime.AddMilliseconds(-Math.Min(precision, distanceToMinInMs));
@@ -101,7 +101,7 @@ namespace FluentAssertions.Primitives
 
             Execute.Assertion
                 .ForCondition(Subject.HasValue && (Subject.Value >= minimumValue) && (Subject.Value <= maximumValue))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be within {0} ms from {1}{reason}, but found {2}.",
                     precision,
                     nearbyTime, Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
@@ -117,15 +117,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> BeBefore(DateTimeOffset expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a {context:date and time} before {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
 
@@ -140,15 +140,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> BeOnOrBefore(DateTimeOffset expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a {context:date and time} on or before {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
 
@@ -163,15 +163,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> BeAfter(DateTimeOffset expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a {context:date and time} after {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
 
@@ -186,15 +186,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> BeOnOrAfter(DateTimeOffset expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a {context:date and time} on or after {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
 
@@ -209,22 +209,22 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> HaveYear(int expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected year {0}{reason}, but found a <null> DateTimeOffset.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Year == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected year {0}{reason}, but found {1}.", expected,
                         Subject.Value.Year);
             }
@@ -240,22 +240,22 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> HaveMonth(int expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected month {0}{reason}, but found a <null> DateTimeOffset.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Month == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected month {0}{reason}, but found {1}.", expected, Subject.Value.Month);
             }
             return new AndConstraint<DateTimeOffsetAssertions>(this);
@@ -269,22 +269,22 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> HaveDay(int expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected day {0}{reason}, but found a <null> DateTimeOffset.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Day == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected day {0}{reason}, but found {1}.", expected, Subject.Value.Day);
             }
 
@@ -299,22 +299,22 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> HaveHour(int expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected hour {0}{reason}, but found a <null> DateTimeOffset.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Hour == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected hour {0}{reason}, but found {1}.", expected, Subject.Value.Hour);
             }
 
@@ -329,22 +329,22 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> HaveMinute(int expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected minute {0}{reason}, but found a <null> DateTimeOffset.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Minute == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected minute {0}{reason}, but found {1}.", expected, Subject.Value.Minute);
             }
 
@@ -359,22 +359,22 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> HaveSecond(int expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected second {0}{reason}, but found a <null> DateTimeOffset.", expected);
 
             if (success)
             {
                 Execute.Assertion
                     .ForCondition(Subject.Value.Second == expected)
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected second {0}{reason}, but found {1}.", expected, Subject.Value.Second);
             }
 

--- a/Src/Core/Primitives/DateTimeOffsetRangeAssertions.cs
+++ b/Src/Core/Primitives/DateTimeOffsetRangeAssertions.cs
@@ -57,15 +57,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> Before(DateTimeOffset target, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected date and/or time {0} to be " + predicate.DisplayText +
                           " {1} before {2}{reason}, but found a <null> DateTime.",
                     subject, timeSpan, target);
@@ -77,7 +77,7 @@ namespace FluentAssertions.Primitives
                 if (!predicate.IsMatchedBy(actual, timeSpan))
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith(
                             "Expected date and/or time {0} to be " + predicate.DisplayText +
                             " {1} before {2}{reason}, but it differs {3}.",
@@ -98,14 +98,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> After(DateTimeOffset target, string because = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> After(DateTimeOffset target, string because = "", params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected date and/or time {0} to be " + predicate.DisplayText +
                           " {1} after {2}{reason}, but found a <null> DateTime.",
                     subject, timeSpan, target);
@@ -117,7 +117,7 @@ namespace FluentAssertions.Primitives
                 if (!predicate.IsMatchedBy(actual, timeSpan))
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith(
                             "Expected date and/or time {0} to be " + predicate.DisplayText +
                             " {1} after {2}{reason}, but it differs {3}.",

--- a/Src/Core/Primitives/DateTimeRangeAssertions.cs
+++ b/Src/Core/Primitives/DateTimeRangeAssertions.cs
@@ -56,15 +56,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         public AndConstraint<DateTimeAssertions> Before(DateTime target, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected date and/or time {0} to be " + predicate.DisplayText +
                           " {1} before {2}{reason}, but found a <null> DateTime.",
                     subject, timeSpan, target);
@@ -76,7 +76,7 @@ namespace FluentAssertions.Primitives
                 if (!predicate.IsMatchedBy(actual, timeSpan))
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith(
                             "Expected date and/or time {0} to be " + predicate.DisplayText +
                             " {1} before {2}{reason}, but it differs {3}.",
@@ -97,15 +97,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         public AndConstraint<DateTimeAssertions> After(DateTime target, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected date and/or time {0} to be " + predicate.DisplayText +
                           " {1} after {2}{reason}, but found a <null> DateTime.",
                     subject, timeSpan, target);
@@ -117,7 +117,7 @@ namespace FluentAssertions.Primitives
                 if (!predicate.IsMatchedBy(actual, timeSpan))
                 {
                     Execute.Assertion
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith(
                             "Expected date and/or time {0} to be " + predicate.DisplayText +
                             " {1} after {2}{reason}, but it differs {3}.",

--- a/Src/Core/Primitives/GuidAssertions.cs
+++ b/Src/Core/Primitives/GuidAssertions.cs
@@ -29,14 +29,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<GuidAssertions> BeEmpty(string because = "", params object[] reasonArgs)
+        public AndConstraint<GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition((Subject.HasValue) && (Subject.Value == Guid.Empty))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected empty Guid{reason}, but found {0}.", Subject);
 
             return new AndConstraint<GuidAssertions>(this);
@@ -49,14 +49,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<GuidAssertions> NotBeEmpty(string because = "", params object[] reasonArgs)
+        public AndConstraint<GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition((Subject.HasValue) && (Subject.Value != Guid.Empty))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect empty Guid{reason}.");
 
             return new AndConstraint<GuidAssertions>(this);
@@ -74,13 +74,13 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<GuidAssertions> Be(string expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs)
         {
             var expectedGuid = new Guid(expected);
-            return Be(expectedGuid, because, reasonArgs);
+            return Be(expectedGuid, because, becauseArgs);
         }
 
         /// <summary>
@@ -91,14 +91,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<GuidAssertions> Be(Guid expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<GuidAssertions> Be(Guid expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Equals(expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<GuidAssertions>(this);
@@ -112,14 +112,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<GuidAssertions> NotBe(Guid unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<GuidAssertions> NotBe(Guid unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.Equals(unexpected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:Guid} to be {0}{reason}.", Subject);
 
             return new AndConstraint<GuidAssertions>(this);

--- a/Src/Core/Primitives/NegatedStringStartValidator.cs
+++ b/Src/Core/Primitives/NegatedStringStartValidator.cs
@@ -7,8 +7,8 @@ namespace FluentAssertions.Primitives
         private readonly StringComparison stringComparison;
 
         public NegatedStringStartValidator(string subject, string expected, StringComparison stringComparison, string because,
-            object[] reasonArgs) :
-                base(subject, expected, because, reasonArgs)
+            object[] becauseArgs) :
+                base(subject, expected, because, becauseArgs)
         {
             this.stringComparison = stringComparison;
         }

--- a/Src/Core/Primitives/NullableBooleanAssertions.cs
+++ b/Src/Core/Primitives/NullableBooleanAssertions.cs
@@ -22,14 +22,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>      
-        public AndConstraint<NullableBooleanAssertions> HaveValue(string because = "", params object[] reasonArgs)
+        public AndConstraint<NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value{reason}.");
 
             return new AndConstraint<NullableBooleanAssertions>(this);
@@ -42,14 +42,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>      
-        public AndConstraint<NullableBooleanAssertions> NotHaveValue(string because = "", params object[] reasonArgs)
+        public AndConstraint<NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect a value{reason}, but found {0}.", Subject);
 
             return new AndConstraint<NullableBooleanAssertions>(this);
@@ -63,14 +63,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> Be(bool? expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject == expected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<BooleanAssertions>(this);
@@ -83,14 +83,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> NotBeFalse(string because = "", params object[] reasonArgs)
+        public AndConstraint<BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || Subject.Value)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected nullable boolean not to be {0}{reason}, but found {1}.", false, Subject);
 
             return new AndConstraint<BooleanAssertions>(this);
@@ -103,14 +103,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> NotBeTrue(string because = "", params object[] reasonArgs)
+        public AndConstraint<BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || !Subject.Value)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected nullable boolean not to be {0}{reason}, but found {1}.", true, Subject);
 
             return new AndConstraint<BooleanAssertions>(this);

--- a/Src/Core/Primitives/NullableDateTimeAssertions.cs
+++ b/Src/Core/Primitives/NullableDateTimeAssertions.cs
@@ -25,14 +25,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>      
-        public AndConstraint<NullableDateTimeAssertions> HaveValue(string because = "", params object[] reasonArgs)
+        public AndConstraint<NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected variable to have a value{reason}, but found {0}", Subject);
 
             return new AndConstraint<NullableDateTimeAssertions>(this);
@@ -45,14 +45,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>      
-        public AndConstraint<NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] reasonArgs)
+        public AndConstraint<NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect variable to have a value{reason}, but found {0}", Subject);
 
             return new AndConstraint<NullableDateTimeAssertions>(this);
@@ -66,14 +66,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> Be(DateTime? expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeAssertions> Be(DateTime? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject == expected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<DateTimeAssertions>(this);

--- a/Src/Core/Primitives/NullableDateTimeOffsetAssertions.cs
+++ b/Src/Core/Primitives/NullableDateTimeOffsetAssertions.cs
@@ -25,14 +25,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>      
-        public AndConstraint<NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] reasonArgs)
+        public AndConstraint<NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected variable to have a value{reason}, but found {0}", Subject);
 
             return new AndConstraint<NullableDateTimeOffsetAssertions>(this);
@@ -45,15 +45,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>      
         public AndConstraint<NullableDateTimeOffsetAssertions> NotHaveValue(string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect variable to have a value{reason}, but found {0}", Subject);
 
             return new AndConstraint<NullableDateTimeOffsetAssertions>(this);
@@ -67,15 +67,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<DateTimeOffsetAssertions> Be(DateTimeOffset? expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject == expected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);

--- a/Src/Core/Primitives/NullableGuidAssertions.cs
+++ b/Src/Core/Primitives/NullableGuidAssertions.cs
@@ -22,14 +22,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>      
-        public AndConstraint<NullableGuidAssertions> HaveValue(string because = "", params object[] reasonArgs)
+        public AndConstraint<NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value{reason}.");
 
             return new AndConstraint<NullableGuidAssertions>(this);
@@ -42,14 +42,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>      
-        public AndConstraint<NullableGuidAssertions> NotHaveValue(string because = "", params object[] reasonArgs)
+        public AndConstraint<NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect a value{reason}, but found {0}.", Subject);
 
             return new AndConstraint<NullableGuidAssertions>(this);
@@ -63,14 +63,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<NullableGuidAssertions> Be(Guid? expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<NullableGuidAssertions> Be(Guid? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject == expected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<NullableGuidAssertions>(this);

--- a/Src/Core/Primitives/NullableSimpleTimeSpanAssertions.cs
+++ b/Src/Core/Primitives/NullableSimpleTimeSpanAssertions.cs
@@ -26,14 +26,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>      
-        public AndConstraint<NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] reasonArgs)
+        public AndConstraint<NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value{reason}.");
 
             return new AndConstraint<NullableSimpleTimeSpanAssertions>(this);
@@ -46,14 +46,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>      
-        public AndConstraint<NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] reasonArgs)
+        public AndConstraint<NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect a value{reason}, but found {0}.", Subject);
 
             return new AndConstraint<NullableSimpleTimeSpanAssertions>(this);
@@ -67,15 +67,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<NullableSimpleTimeSpanAssertions> Be(TimeSpan? expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject == expected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<NullableSimpleTimeSpanAssertions>(this);

--- a/Src/Core/Primitives/ObjectAssertions.cs
+++ b/Src/Core/Primitives/ObjectAssertions.cs
@@ -27,13 +27,13 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<ObjectAssertions> Be(object expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject.IsSameOrEqualTo(expected))
                 .FailWith("Expected {context:object} to be {0}{reason}, but found {1}.", expected,
                     Subject);
@@ -49,14 +49,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<ObjectAssertions> NotBe(object unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.IsSameOrEqualTo(unexpected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:object} to be equal to {0}{reason}.", unexpected);
 
             return new AndConstraint<ObjectAssertions>(this);
@@ -70,14 +70,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
         public AndConstraint<ObjectAssertions> HaveFlag(Enum expectedFlag, string because = "", 
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .ForCondition(!ReferenceEquals(Subject, null))
                 .FailWith("Expected type to be {0}{reason}, but found <null>.", expectedFlag.GetType())
                 .Then
@@ -99,14 +99,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
         public AndConstraint<ObjectAssertions> NotHaveFlag(Enum unexpectedFlag, string because = "", 
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .ForCondition(!ReferenceEquals(Subject, null))
                 .FailWith("Expected type to be {0}{reason}, but found <null>.", unexpectedFlag.GetType())
                 .Then

--- a/Src/Core/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/Core/Primitives/ReferenceTypeAssertions.cs
@@ -25,14 +25,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeNull(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(ReferenceEquals(Subject, null))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:" + Context + "} to be <null>{reason}, but found {0}.", Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -45,14 +45,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotBeNull(string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:" + Context + "} not to be <null>{reason}.");
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -66,15 +66,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .UsingLineBreaks
                 .ForCondition(ReferenceEquals(Subject, expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:object} to refer to {0}{reason}, but found object {1}.", expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -88,15 +88,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .UsingLineBreaks
                 .ForCondition(!ReferenceEquals(Subject, unexpected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect reference to object {0}{reason}.", unexpected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -110,12 +110,12 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndWhichConstraint<TAssertions, T> BeOfType<T>(string because = "", params object[] reasonArgs)
+        public AndWhichConstraint<TAssertions, T> BeOfType<T>(string because = "", params object[] becauseArgs)
         {
-            BeOfType(typeof(T), because, reasonArgs);
+            BeOfType(typeof(T), because, becauseArgs);
 
             return new AndWhichConstraint<TAssertions, T>((TAssertions)this, (T)(object)Subject);
         }
@@ -130,17 +130,17 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeOfType(Type expectedType, string because = "", params object[] reasonArgs)
+        public AndConstraint<TAssertions> BeOfType(Type expectedType, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type to be {0}{reason}, but found <null>.", expectedType);
 
-            Subject.GetType().Should().Be(expectedType, because, reasonArgs);
+            Subject.GetType().Should().Be(expectedType, because, becauseArgs);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -150,13 +150,13 @@ namespace FluentAssertions.Primitives
         /// </summary>
         /// <typeparam name="T">The type to which the object should be assignable.</typeparam>
         /// <param name="because">The reason why the object should be assignable to the type.</param>
-        /// <param name="reasonArgs">The parameters used when formatting the <paramref name="because"/>.</param>
+        /// <param name="becauseArgs">The parameters used when formatting the <paramref name="because"/>.</param>
         /// <returns>An <see cref="AndWhichConstraint{TAssertions, T}"/> which can be used to chain assertions.</returns>
-        public AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] reasonArgs)
+        public AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject is T)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:" + Context + "} to be assignable to {0}{reason}, but {1} is not",
                     typeof(T),
                     Subject.GetType());
@@ -169,13 +169,13 @@ namespace FluentAssertions.Primitives
         /// </summary>
         /// <param name="predicate">The predicate which must be satisfied by the <typeparamref name="TSubject" />.</param>
         /// <param name="because">The reason why the predicate should be satisfied.</param>
-        /// <param name="reasonArgs">The parameters used when formatting the <paramref name="because" />.</param>
+        /// <param name="becauseArgs">The parameters used when formatting the <paramref name="because" />.</param>
         /// <returns>An <see cref="AndConstraint{T}" /> which can be used to chain assertions.</returns>
         public AndConstraint<TAssertions> Match(Expression<Func<TSubject, bool>> predicate,
             string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
-            return Match<TSubject>(predicate, because, reasonArgs);
+            return Match<TSubject>(predicate, because, becauseArgs);
         }
 
         /// <summary>
@@ -183,11 +183,11 @@ namespace FluentAssertions.Primitives
         /// </summary>
         /// <param name="predicate">The predicate which must be satisfied by the <typeparamref name="TSubject" />.</param>
         /// <param name="because">The reason why the predicate should be satisfied.</param>
-        /// <param name="reasonArgs">The parameters used when formatting the <paramref name="because" />.</param>
+        /// <param name="becauseArgs">The parameters used when formatting the <paramref name="because" />.</param>
         /// <returns>An <see cref="AndConstraint{T}" /> which can be used to chain assertions.</returns>
         public AndConstraint<TAssertions> Match<T>(Expression<Func<T, bool>> predicate,
             string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
             where T : TSubject
         {
             if (predicate == null)
@@ -197,7 +197,7 @@ namespace FluentAssertions.Primitives
 
             Execute.Assertion
                 .ForCondition(predicate.Compile()((T)Subject))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0} to match {1}{reason}.", Subject, predicate.Body);
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/Core/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/Core/Primitives/SimpleTimeSpanAssertions.cs
@@ -31,14 +31,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BePositive(string because = "", params object[] reasonArgs)
+        public AndConstraint<SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(new TimeSpan()) > 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected positive value{reason}, but found {0}", Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
@@ -51,14 +51,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] reasonArgs)
+        public AndConstraint<SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(new TimeSpan()) < 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected negative value{reason}, but found {0}", Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
@@ -73,14 +73,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> Be(TimeSpan expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<SimpleTimeSpanAssertions> Be(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) == 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
@@ -95,14 +95,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> NotBe(TimeSpan unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<SimpleTimeSpanAssertions> NotBe(TimeSpan unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(unexpected) != 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {0}{reason}.", unexpected);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
@@ -117,14 +117,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BeLessThan(TimeSpan expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<SimpleTimeSpanAssertions> BeLessThan(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) < 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value less than {0}{reason}, but found {1}.", expected, Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
@@ -139,14 +139,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BeLessOrEqualTo(TimeSpan expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<SimpleTimeSpanAssertions> BeLessOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) <= 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value less or equal to {0}{reason}, but found {1}.", expected, Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
@@ -161,14 +161,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BeGreaterThan(TimeSpan expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<SimpleTimeSpanAssertions> BeGreaterThan(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) > 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value greater than {0}{reason}, but found {1}.", expected, Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
@@ -183,15 +183,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<SimpleTimeSpanAssertions> BeGreaterOrEqualTo(TimeSpan expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) >= 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value greater or equal to {0}{reason}, but found {1}.", expected, Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
@@ -205,8 +205,6 @@ namespace FluentAssertions.Primitives
         /// Use this assertion when, for example the database truncates datetimes to nearest 20ms. If you want to assert to the exact datetime,
         /// use <see cref="Be"/>.
         /// </remarks>
-        /// <param name="expected"></param>
-        /// <param name="i"></param>
         /// <param name="nearbyTime">
         /// The expected time to compare the actual value with.
         /// </param>
@@ -217,18 +215,18 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<SimpleTimeSpanAssertions> BeCloseTo(TimeSpan nearbyTime, int precision = 20, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             var minimumValue = new TimeSpan(nearbyTime.Days, nearbyTime.Hours, nearbyTime.Minutes, nearbyTime.Seconds, nearbyTime.Milliseconds - precision);
             var maximumValue = new TimeSpan(nearbyTime.Days, nearbyTime.Hours, nearbyTime.Minutes, nearbyTime.Seconds, nearbyTime.Milliseconds + precision);
 
             Execute.Assertion
                 .ForCondition(Subject.HasValue && (Subject.Value >= minimumValue) && (Subject.Value <= maximumValue))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:time} to be within {0} ms from {1}{reason}, but found {2}.", precision,
                     nearbyTime, Subject.HasValue ? Subject.Value : default(TimeSpan?));
 

--- a/Src/Core/Primitives/StringAssertions.cs
+++ b/Src/Core/Primitives/StringAssertions.cs
@@ -30,12 +30,12 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> Be(string expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> Be(string expected, string because = "", params object[] becauseArgs)
         {
-            new StringEqualityValidator(Subject, expected, StringComparison.CurrentCulture, because, reasonArgs).Validate();
+            new StringEqualityValidator(Subject, expected, StringComparison.CurrentCulture, because, becauseArgs).Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -61,14 +61,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> BeOneOf(IEnumerable<string> validValues, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> BeOneOf(IEnumerable<string> validValues, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(validValues.Contains(Subject))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected value to be one of {0}{reason}, but found {1}.", validValues, Subject);
 
             return new AndConstraint<StringAssertions>(this);
@@ -85,14 +85,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<StringAssertions> BeEquivalentTo(string expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             var expectation = new StringEqualityValidator(
-                Subject, expected, StringComparison.CurrentCultureIgnoreCase, because, reasonArgs);
+                Subject, expected, StringComparison.CurrentCultureIgnoreCase, because, becauseArgs);
 
             expectation.Validate();
 
@@ -108,14 +108,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotBe(string unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject != unexpected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string not to be {0}{reason}.", unexpected);
 
             return new AndConstraint<StringAssertions>(this);
@@ -131,12 +131,12 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> Match(string wildcardPattern, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs)
         {
-            new StringWildcardMatchingValidator(Subject, wildcardPattern, because, reasonArgs).Validate();
+            new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs).Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -151,12 +151,12 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs)
         {
-            new StringWildcardMatchingValidator(Subject, wildcardPattern, because, reasonArgs)
+            new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
             {
                 Negate = true
             }.Validate();
@@ -174,13 +174,13 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
-            var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, reasonArgs)
+            var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
             {
                 IgnoreCase = true,
                 IgnoreNewLineDifferences = true
@@ -201,13 +201,13 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
-            var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, reasonArgs)
+            var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
             {
                 IgnoreCase = true,
                 IgnoreNewLineDifferences = true,
@@ -229,10 +229,10 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs)
         {
           if (regularExpression == null)
           {
@@ -242,7 +242,7 @@ namespace FluentAssertions.Primitives
           Execute.Assertion
               .ForCondition(!ReferenceEquals(Subject, null))
               .UsingLineBreaks
-              .BecauseOf(because, reasonArgs)
+              .BecauseOf(because, becauseArgs)
               .FailWith("Expected string to match regex {0}{reason}, but it was <null>.", regularExpression);
 
           bool isMatch;
@@ -260,7 +260,7 @@ namespace FluentAssertions.Primitives
 
           Execute.Assertion
               .ForCondition(isMatch)
-              .BecauseOf(because, reasonArgs)
+              .BecauseOf(because, becauseArgs)
               .UsingLineBreaks
               .FailWith("Expected string to match regex {0}{reason}, but {1} does not match.", regularExpression, Subject);
 
@@ -277,10 +277,10 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs)
         {
           if (regularExpression == null)
           {
@@ -290,7 +290,7 @@ namespace FluentAssertions.Primitives
           Execute.Assertion
               .ForCondition(!ReferenceEquals(Subject, null))
               .UsingLineBreaks
-              .BecauseOf(because, reasonArgs)
+              .BecauseOf(because, becauseArgs)
               .FailWith("Expected string to not match regex {0}{reason}, but it was <null>.", regularExpression);
           
           bool isMatch;
@@ -308,7 +308,7 @@ namespace FluentAssertions.Primitives
 
           Execute.Assertion
               .ForCondition(!isMatch)
-              .BecauseOf(because, reasonArgs)
+              .BecauseOf(because, becauseArgs)
               .UsingLineBreaks
               .FailWith("Did not expect string to match regex {0}{reason}, but {1} matches.", regularExpression, Subject);
 
@@ -324,10 +324,10 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> StartWith(string expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -339,7 +339,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare start of string with empty string.");
             }
 
-            new StringStartValidator(Subject, expected, StringComparison.CurrentCulture, because, reasonArgs).Validate();
+            new StringStartValidator(Subject, expected, StringComparison.CurrentCulture, because, becauseArgs).Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -353,10 +353,10 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotStartWith(string unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs)
         {
             if (unexpected == null)
             {
@@ -368,7 +368,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare start of string with empty string.");
             }
 
-            new NegatedStringStartValidator(Subject, unexpected, StringComparison.CurrentCulture, because, reasonArgs).Validate();
+            new NegatedStringStartValidator(Subject, unexpected, StringComparison.CurrentCulture, because, becauseArgs).Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -382,11 +382,11 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<StringAssertions> StartWithEquivalent(string expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -398,7 +398,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare string start equivalence with empty string.");
             }
 
-            new StringStartValidator(Subject, expected, StringComparison.CurrentCultureIgnoreCase, because, reasonArgs).Validate();
+            new StringStartValidator(Subject, expected, StringComparison.CurrentCultureIgnoreCase, because, becauseArgs).Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -412,10 +412,10 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs)
         {
             if (unexpected == null)
             {
@@ -427,7 +427,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare start of string with empty string.");
             }
 
-            new NegatedStringStartValidator(Subject, unexpected, StringComparison.CurrentCultureIgnoreCase, because, reasonArgs).Validate();
+            new NegatedStringStartValidator(Subject, unexpected, StringComparison.CurrentCultureIgnoreCase, because, becauseArgs).Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -441,10 +441,10 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> EndWith(string expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -459,20 +459,20 @@ namespace FluentAssertions.Primitives
             if (Subject == null)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected string {0} to end with {1}{reason}.", Subject, expected);
             }
 
             if (Subject.Length < expected.Length)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected string to end with {0}{reason}, but {1} is too short.", expected, Subject);
             }
 
             Execute.Assertion
                 .ForCondition(Subject.EndsWith(expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string {0} to end with {1}{reason}.", Subject, expected);
 
             return new AndConstraint<StringAssertions>(this);
@@ -487,10 +487,10 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotEndWith(string unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs)
         {
             if (unexpected == null)
             {
@@ -505,13 +505,13 @@ namespace FluentAssertions.Primitives
             if (Subject == null)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected string that does not end with {1}, but found {0}.", Subject, unexpected);
             }
 
             Execute.Assertion
                 .ForCondition(!Subject.EndsWith(unexpected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string {0} not to end with {1}{reason}.", Subject, unexpected);
 
             return new AndConstraint<StringAssertions>(this);
@@ -526,10 +526,10 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -544,20 +544,20 @@ namespace FluentAssertions.Primitives
             if (Subject == null)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected string that ends with equivalent of {0}{reason}, but found {1}.", expected, Subject);
             }
 
             if (Subject.Length < expected.Length)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected string to end with equivalent of {0}{reason}, but {1} is too short.", expected, Subject);
             }
 
             Execute.Assertion
                 .ForCondition(Subject.EndsWith(expected, StringComparison.CurrentCultureIgnoreCase))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string that ends with equivalent of {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<StringAssertions>(this);
@@ -572,10 +572,10 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs)
         {
             if (unexpected == null)
             {
@@ -590,13 +590,13 @@ namespace FluentAssertions.Primitives
             if (Subject == null)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected string that does not end with equivalent of {0}, but found {1}.", unexpected, Subject);
             }
 
             Execute.Assertion
                 .ForCondition(!Subject.EndsWith(unexpected, StringComparison.CurrentCultureIgnoreCase))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string that does not end with equivalent of {0}{reason}, but found {1}.", unexpected, Subject);
 
             return new AndConstraint<StringAssertions>(this);
@@ -612,10 +612,10 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> Contain(string expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -629,7 +629,7 @@ namespace FluentAssertions.Primitives
 
             Execute.Assertion
                 .ForCondition(Contains(Subject, expected, StringComparison.Ordinal))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string {0} to contain {1}{reason}.", Subject, expected);
 
             return new AndConstraint<StringAssertions>(this);
@@ -644,10 +644,10 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -661,7 +661,7 @@ namespace FluentAssertions.Primitives
 
             Execute.Assertion
                 .ForCondition(Contains(Subject, expected, StringComparison.CurrentCultureIgnoreCase))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string to contain equivalent of {0}{reason} but found {1}", expected, Subject);
 
             return new AndConstraint<StringAssertions>(this);
@@ -677,11 +677,11 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<StringAssertions> NotContain(string expected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -695,7 +695,7 @@ namespace FluentAssertions.Primitives
 
             Execute.Assertion
                 .ForCondition(!Contains(Subject, expected, StringComparison.Ordinal))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect string {0} to contain {1}{reason}.", Subject, expected);
 
             return new AndConstraint<StringAssertions>(this);
@@ -710,15 +710,15 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<StringAssertions> NotContainEquivalentOf(string unexpected, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Contains(Subject, unexpected, StringComparison.CurrentCultureIgnoreCase))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect string to contain equivalent of {0}{reason} but found {1}", unexpected, Subject);
 
             return new AndConstraint<StringAssertions>(this);
@@ -736,14 +736,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> BeEmpty(string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> BeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition((Subject != null) && (Subject.Length == 0))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected empty string{reason}, but found {0}.", Subject);
 
             return new AndConstraint<StringAssertions>(this);
@@ -756,14 +756,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotBeEmpty(string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Length > 0)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect empty string{reason}.");
 
             return new AndConstraint<StringAssertions>(this);
@@ -777,14 +777,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> HaveLength(int expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Length == expected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string with length {0}{reason}, but found string {1} with length {2}.",
                     expected, Subject, Subject.Length);
 
@@ -798,14 +798,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<StringAssertions> NotBeNullOrEmpty(string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!string.IsNullOrEmpty(Subject))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string not to be <null> or empty{reason}, but found {0}.", Subject);
 
             return new AndConstraint<StringAssertions>(this);
@@ -818,14 +818,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<StringAssertions> BeNullOrEmpty(string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(string.IsNullOrEmpty(Subject))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string to be <null> or empty{reason}, but found {0}.", Subject);
 
             return new AndConstraint<StringAssertions>(this);
@@ -838,14 +838,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!IsBlank(Subject))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string not to be <null> or whitespace{reason}, but found {0}.", Subject);
 
             return new AndConstraint<StringAssertions>(this);
@@ -858,14 +858,14 @@ namespace FluentAssertions.Primitives
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] reasonArgs)
+        public AndConstraint<StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(IsBlank(Subject))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected string to be <null> or whitespace{reason}, but found {0}.", Subject);
 
             return new AndConstraint<StringAssertions>(this);

--- a/Src/Core/Primitives/StringEqualityValidator.cs
+++ b/Src/Core/Primitives/StringEqualityValidator.cs
@@ -8,8 +8,8 @@ namespace FluentAssertions.Primitives
         private readonly StringComparison comparisonMode;
 
         public StringEqualityValidator(string subject, string expected, StringComparison comparisonMode, string because,
-            object[] reasonArgs) :
-                base(subject, expected, because, reasonArgs)
+            object[] becauseArgs) :
+                base(subject, expected, because, becauseArgs)
         {
             this.comparisonMode = comparisonMode;
         }

--- a/Src/Core/Primitives/StringStartValidator.cs
+++ b/Src/Core/Primitives/StringStartValidator.cs
@@ -8,8 +8,8 @@ namespace FluentAssertions.Primitives
         private readonly StringComparison stringComparison;
 
         public StringStartValidator(string subject, string expected, StringComparison stringComparison, string because,
-            object[] reasonArgs) :
-                base(subject, expected, because, reasonArgs)
+            object[] becauseArgs) :
+                base(subject, expected, because, becauseArgs)
         {
             this.stringComparison = stringComparison;
         }

--- a/Src/Core/Primitives/StringValidator.cs
+++ b/Src/Core/Primitives/StringValidator.cs
@@ -17,9 +17,9 @@ namespace FluentAssertions.Primitives
 
         #endregion
 
-        protected StringValidator(string subject, string expected, string because, object[] reasonArgs)
+        protected StringValidator(string subject, string expected, string because, object[] becauseArgs)
         {
-            assertion = Execute.Assertion.BecauseOf(because, reasonArgs);
+            assertion = Execute.Assertion.BecauseOf(because, becauseArgs);
 
             this.subject = subject;
             this.expected = expected;

--- a/Src/Core/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/Core/Primitives/StringWildcardMatchingValidator.cs
@@ -7,8 +7,8 @@ namespace FluentAssertions.Primitives
 {
     internal class StringWildcardMatchingValidator : StringValidator
     {
-        public StringWildcardMatchingValidator(string subject, string expected, string because, object[] reasonArgs)
-            : base(subject, expected, because, reasonArgs)
+        public StringWildcardMatchingValidator(string subject, string expected, string because, object[] becauseArgs)
+            : base(subject, expected, because, becauseArgs)
         {
         }
 

--- a/Src/Core/PropertyChangedSourceExtensions.cs
+++ b/Src/Core/PropertyChangedSourceExtensions.cs
@@ -41,7 +41,7 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         /// <remarks>
@@ -50,7 +50,7 @@ namespace FluentAssertions
         /// </remarks>
         public static IEventRecorder ShouldRaisePropertyChangeFor<T>(
             this T eventSource, Expression<Func<T, object>> propertyExpression,
-            string because, params object[] reasonArgs)
+            string because, params object[] becauseArgs)
         {
             EventRecorder eventRecorder = eventSource.GetRecorderForEvent(PropertyChangedEventName);
             string propertyName = (propertyExpression != null) ? propertyExpression.GetPropertyInfo().Name : null;
@@ -58,7 +58,7 @@ namespace FluentAssertions
             if (!eventRecorder.Any())
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected object {0} to raise event {1} for property {2}{reason}, but it did not.",
                         eventSource, PropertyChangedEventName, propertyName);
             }
@@ -90,7 +90,7 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         /// <remarks>
@@ -99,7 +99,7 @@ namespace FluentAssertions
         /// </remarks>
         public static void ShouldNotRaisePropertyChangeFor<T>(
             this T eventSource, Expression<Func<T, object>> propertyExpression,
-            string because, params object[] reasonArgs)
+            string because, params object[] becauseArgs)
         {
             EventRecorder eventRecorder = eventSource.GetRecorderForEvent(PropertyChangedEventName);
 
@@ -108,7 +108,7 @@ namespace FluentAssertions
             if (eventRecorder.Any(@event => GetAffectedPropertyName(@event) == propertyName))
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect object {0} to raise the {1} event for property {2}{reason}, but it did.",
                         eventSource, PropertyChangedEventName, propertyName);
             }

--- a/Src/Core/Specialized/ActionAssertions.cs
+++ b/Src/Core/Specialized/ActionAssertions.cs
@@ -29,10 +29,10 @@ namespace FluentAssertions.Specialized
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public ExceptionAssertions<TException> ShouldThrow<TException>(string because = "", params object[] reasonArgs)
+        public ExceptionAssertions<TException> ShouldThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : Exception
         {
             Exception actualException = InvokeSubjectWithInterception();
@@ -40,12 +40,12 @@ namespace FluentAssertions.Specialized
 
             Execute.Assertion
                 .ForCondition(actualException != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a <{0}> to be thrown{reason}, but no exception was thrown.", typeof(TException));
 
             Execute.Assertion
                 .ForCondition(expectedExceptions.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected a <{0}> to be thrown{reason}, but found a <{1}>: {3}.",
                     typeof (TException), actualException.GetType(),
@@ -62,10 +62,10 @@ namespace FluentAssertions.Specialized
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void ShouldNotThrow<TException>(string because = "", params object[] reasonArgs) where TException : Exception
+        public void ShouldNotThrow<TException>(string because = "", params object[] becauseArgs) where TException : Exception
         {
             Exception actualException = InvokeSubjectWithInterception();
             IEnumerable<TException> expectedExceptions = extractor.OfType<TException>(actualException);
@@ -74,7 +74,7 @@ namespace FluentAssertions.Specialized
             {
                 Execute.Assertion
                     .ForCondition(!expectedExceptions.Any())
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect {0}{reason}, but found {1}.", typeof (TException), actualException);
             }
         }
@@ -86,10 +86,10 @@ namespace FluentAssertions.Specialized
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void ShouldNotThrow(string because = "", params object[] reasonArgs)
+        public void ShouldNotThrow(string because = "", params object[] becauseArgs)
         {
             try
             {
@@ -98,7 +98,7 @@ namespace FluentAssertions.Specialized
             catch (Exception exception)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect any exception{reason}, but found {0}", exception);
             }
         }

--- a/Src/Core/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/Core/Specialized/AsyncFunctionAssertions.cs
@@ -33,10 +33,10 @@ namespace FluentAssertions.Specialized
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public ExceptionAssertions<TException> ShouldThrow<TException>(string because = "", params object[] reasonArgs)
+        public ExceptionAssertions<TException> ShouldThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : Exception
         {
             Exception exception = InvokeSubjectWithInterception();
@@ -44,12 +44,12 @@ namespace FluentAssertions.Specialized
 
             Execute.Assertion
                 .ForCondition(exception != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but no exception was thrown.", typeof(TException));
 
             Execute.Assertion
                 .ForCondition(exceptions.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", typeof(TException), exception);
 
             return new ExceptionAssertions<TException>(exceptions);
@@ -62,10 +62,10 @@ namespace FluentAssertions.Specialized
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void ShouldNotThrow(string because = "", params object[] reasonArgs)
+        public void ShouldNotThrow(string because = "", params object[] becauseArgs)
         {
             try
             {
@@ -77,7 +77,7 @@ namespace FluentAssertions.Specialized
                 Exception exception = aggregateException.InnerException;
 
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect any exception{reason}, but found a {0} with message {1}.",
                         exception.GetType(), exception.Message);
             }
@@ -90,10 +90,10 @@ namespace FluentAssertions.Specialized
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void ShouldNotThrow<TException>(string because = "", params object[] reasonArgs)
+        public void ShouldNotThrow<TException>(string because = "", params object[] becauseArgs)
         {
             try
             {
@@ -108,7 +108,7 @@ namespace FluentAssertions.Specialized
                 {
                     Execute.Assertion
                         .ForCondition(!(exception is TException))
-                        .BecauseOf(because, reasonArgs)
+                        .BecauseOf(because, becauseArgs)
                         .FailWith("Did not expect {0}{reason}, but found one with message {1}.",
                             typeof(TException), exception.Message);
                 }

--- a/Src/Core/Specialized/ExceptionAssertions.cs
+++ b/Src/Core/Specialized/ExceptionAssertions.cs
@@ -67,23 +67,23 @@ namespace FluentAssertions.Specialized
         /// <param name = "expectedMessage">
         ///   The expected message of the exception.
         /// </param>
-        /// <param name = "reason">
+        /// <param name = "because">
         ///   A formatted phrase as is supported by <see cref = "string.Format(string,object[])" /> explaining why the assertion 
         ///   is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name = "reasonArgs">
-        ///   Zero or more objects to format using the placeholders in <see cref = "reason" />.
+        /// <param name = "becauseArgs">
+        ///   Zero or more objects to format using the placeholders in <see cref = "because" />.
         /// </param>
         public virtual ExceptionAssertions<TException> WithMessage(string expectedMessage, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
-            AssertionScope assertion = Execute.Assertion.BecauseOf(because, reasonArgs).UsingLineBreaks;
+            AssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs).UsingLineBreaks;
 
             assertion
                 .ForCondition(Subject.Any())
                 .FailWith("Expected exception with message {0}{reason}, but no exception was thrown.", expectedMessage);
 
-            outerMessageAssertion.Execute(Subject.Select(exc => exc.Message).ToArray(), expectedMessage, because, reasonArgs);
+            outerMessageAssertion.Execute(Subject.Select(exc => exc.Message).ToArray(), expectedMessage, because, becauseArgs);
 
             return this;
         }
@@ -110,25 +110,25 @@ namespace FluentAssertions.Specialized
         ///   Asserts that the thrown exception contains an inner exception of type <typeparamref name = "TInnerException" />.
         /// </summary>
         /// <typeparam name = "TInnerException">The expected type of the inner exception.</typeparam>
-        /// <param name = "reason">The reason why the inner exception should be of the supplied type.</param>
-        /// <param name = "reasonArgs">The parameters used when formatting the <paramref name = "because" />.</param>
+        /// <param name = "because">The reason why the inner exception should be of the supplied type.</param>
+        /// <param name = "becauseArgs">The parameters used when formatting the <paramref name = "because" />.</param>
         public virtual ExceptionAssertions<TException> WithInnerException<TInnerException>(string because,
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected inner {0}{reason}, but no exception was thrown.", typeof(TInnerException));
 
             Execute.Assertion
                 .ForCondition(Subject.Any(e => e.InnerException != null))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected inner {0}{reason}, but the thrown exception has no inner exception.",
                     typeof(TInnerException));
 
             Execute.Assertion
                 .ForCondition(Subject.Any(e => e.InnerException is TInnerException))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected inner {0}{reason}, but found {1}.", typeof(TInnerException), SingleSubject.InnerException);
 
             return this;
@@ -138,16 +138,16 @@ namespace FluentAssertions.Specialized
         ///   Asserts that the thrown exception contains an inner exception of the exact type <typeparamref name = "TInnerException" /> (and not a derived exception type).
         /// </summary>
         /// <typeparam name = "TInnerException">The expected type of the inner exception.</typeparam>
-        /// <param name = "reason">The reason why the inner exception should be of the supplied type.</param>
-        /// <param name = "reasonArgs">The parameters used when formatting the <paramref name = "because" />.</param>
+        /// <param name = "because">The reason why the inner exception should be of the supplied type.</param>
+        /// <param name = "becauseArgs">The parameters used when formatting the <paramref name = "because" />.</param>
         public virtual ExceptionAssertions<TException> WithInnerExceptionExactly<TInnerException>(string because,
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
-            WithInnerException<TInnerException>(because, reasonArgs);
+            WithInnerException<TInnerException>(because, becauseArgs);
 
             Execute.Assertion
                 .ForCondition(Subject.Any(e => e.InnerException.GetType() == typeof(TInnerException)))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected inner {0}{reason}, but found {1}.", typeof(TInnerException), SingleSubject.InnerException);
 
             return this;
@@ -157,15 +157,15 @@ namespace FluentAssertions.Specialized
         ///   Asserts that the thrown exception contains an inner exception with the <paramref name = "expectedInnerMessage" />.
         /// </summary>
         /// <param name = "expectedInnerMessage">The expected message of the inner exception.</param>
-        /// <param name = "reason">
+        /// <param name = "because">
         ///   The reason why the message of the inner exception should match <paramref name = "expectedInnerMessage" />.
         /// </param>
-        /// <param name = "reasonArgs">The parameters used when formatting the <paramref name = "because" />.</param>
+        /// <param name = "becauseArgs">The parameters used when formatting the <paramref name = "because" />.</param>
         public virtual ExceptionAssertions<TException> WithInnerMessage(string expectedInnerMessage, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             AssertionScope assertion = Execute.Assertion
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .UsingLineBreaks;
 
             assertion
@@ -178,7 +178,7 @@ namespace FluentAssertions.Specialized
 
             string[] subjectInnerMessage = Subject.Select(e => e.InnerException.Message).ToArray();
 
-            innerMessageAssertion.Execute(subjectInnerMessage, expectedInnerMessage, because, reasonArgs);
+            innerMessageAssertion.Execute(subjectInnerMessage, expectedInnerMessage, because, becauseArgs);
 
             return this;
         }
@@ -189,20 +189,20 @@ namespace FluentAssertions.Specialized
         /// <param name = "exceptionExpression">
         ///   The condition that the exception must match.
         /// </param>
-        /// <param name = "reason">
+        /// <param name = "because">
         ///   A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         ///   start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name = "reasonArgs">
+        /// <param name = "becauseArgs">
         ///   Zero or more values to use for filling in any <see cref = "string.Format(string,object[])" /> compatible placeholders.
         /// </param>
         public ExceptionAssertions<TException> Where(Expression<Func<TException, bool>> exceptionExpression,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             Func<TException, bool> condition = exceptionExpression.Compile();
             Execute.Assertion
                 .ForCondition(condition(SingleSubject))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected exception where {0}{reason}, but the condition was not met by:\r\n\r\n{1}",
                     exceptionExpression.Body, Subject);
 
@@ -243,7 +243,7 @@ namespace FluentAssertions.Specialized
 
             public string Context { get; set; }
 
-            public void Execute(IEnumerable<string> messages, string expectation, string because, params object[] reasonArgs)
+            public void Execute(IEnumerable<string> messages, string expectation, string because, params object[] becauseArgs)
             {
                 using (new AssertionScope())
                 {
@@ -255,7 +255,7 @@ namespace FluentAssertions.Specialized
                         {
                             scope.AddNonReportable("context", Context);
 
-                            message.Should().MatchEquivalentOf(expectation, because, reasonArgs);
+                            message.Should().MatchEquivalentOf(expectation, because, becauseArgs);
 
                             results.AddSet(message, scope.Discard());
                         }

--- a/Src/Core/Types/MemberInfoAssertions.cs
+++ b/Src/Core/Types/MemberInfoAssertions.cs
@@ -25,14 +25,14 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndWhichConstraint<MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            return BeDecoratedWith<TAttribute>(attr => true, because, reasonArgs);
+            return BeDecoratedWith<TAttribute>(attr => true, because, becauseArgs);
         }
 
         /// <summary>
@@ -42,14 +42,14 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            return NotBeDecoratedWith<TAttribute>(attr => true, because, reasonArgs);
+            return NotBeDecoratedWith<TAttribute>(attr => true, because, becauseArgs);
         }
 
         /// <summary>
@@ -63,12 +63,12 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndWhichConstraint<MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(
             Expression<Func<TAttribute, bool>> isMatchingAttributePredicate,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
             string failureMessage = String.Format("Expected {0} {1}" +
@@ -79,7 +79,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(attributes.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(failureMessage);
 
             return new AndWhichConstraint<MemberInfoAssertions<TSubject, TAssertions>, TAttribute>(this, attributes);
@@ -96,12 +96,12 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(
             Expression<Func<TAttribute, bool>> isMatchingAttributePredicate,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
             string failureMessage = String.Format("Expected {0} {1}" +
@@ -112,7 +112,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(!attributes.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(failureMessage);
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/Core/Types/MethodBaseAssertions.cs
+++ b/Src/Core/Types/MethodBaseAssertions.cs
@@ -23,14 +23,14 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TAssertions> HaveAccessModifier(
-            CSharpAccessModifier accessModifier, string because = "", params object[] reasonArgs)
+            CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion.ForCondition(accessModifier == Subject.GetCSharpAccessModifier())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected method " + Subject.Name + " to be {0}{reason}, but it is {1}.",
                     accessModifier, Subject.GetCSharpAccessModifier());
 

--- a/Src/Core/Types/MethodInfoAssertions.cs
+++ b/Src/Core/Types/MethodInfoAssertions.cs
@@ -25,11 +25,11 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<MethodInfoAssertions> BeVirtual(
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             string failureMessage = "Expected method " +
                                     SubjectDescription +
@@ -37,7 +37,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(!Subject.IsNonVirtual())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(failureMessage);
 
             return new AndConstraint<MethodInfoAssertions>(this);
@@ -48,8 +48,8 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<MethodInfoAssertions> BeAsync(string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs)
         {
             string failureMessage = "Expected subject " +
                         SubjectDescription +
@@ -57,7 +57,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(Subject.IsAsync())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(failureMessage);
 
             return new AndConstraint<MethodInfoAssertions>(this);
@@ -70,13 +70,13 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> ReturnVoid(string because = "", params object[] reasonArgs)
+        public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion.ForCondition(typeof(void) == Subject.ReturnType)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the return type of method " + Subject.Name + " to be void {reason}, but it is {0}.",
                     Subject.ReturnType.FullName);
 
@@ -91,13 +91,13 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> Return(Type returnType, string because = "", params object[] reasonArgs)
+        public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> Return(Type returnType, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion.ForCondition(returnType == Subject.ReturnType)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the return type of method " + Subject.Name + " to be {0} {reason}, but it is {1}.",
                     returnType, Subject.ReturnType.FullName);
 
@@ -112,12 +112,12 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] reasonArgs)
+        public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs)
         {
-            return Return(typeof (TReturn), because, reasonArgs);
+            return Return(typeof (TReturn), because, becauseArgs);
         }
 
 

--- a/Src/Core/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/Core/Types/MethodInfoSelectorAssertions.cs
@@ -36,10 +36,10 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<MethodInfoSelectorAssertions> BeVirtual(string because = "", params object[] reasonArgs)
+        public AndConstraint<MethodInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs)
         {
             IEnumerable<MethodInfo> nonVirtualMethods = GetAllNonVirtualMethodsFromSelection();
 
@@ -49,7 +49,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(!nonVirtualMethods.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(failureMessage);
 
             return new AndConstraint<MethodInfoSelectorAssertions>(this);
@@ -72,13 +72,13 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] reasonArgs)
+        public AndConstraint<MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            return BeDecoratedWith<TAttribute>(attr => true, because, reasonArgs);
+            return BeDecoratedWith<TAttribute>(attr => true, because, becauseArgs);
         }
 
         /// <summary>
@@ -92,11 +92,11 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(
-            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate,  string because = "", params object[] reasonArgs)
+            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate,  string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
             IEnumerable<MethodInfo> methodsWithoutAttribute = GetMethodsWithout<TAttribute>(isMatchingAttributePredicate);
@@ -107,7 +107,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(!methodsWithoutAttribute.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(failureMessage, typeof(TAttribute));
 
             return new AndConstraint<MethodInfoSelectorAssertions>(this);

--- a/Src/Core/Types/PropertyInfoAssertions.cs
+++ b/Src/Core/Types/PropertyInfoAssertions.cs
@@ -25,11 +25,11 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<PropertyInfoAssertions> BeVirtual(
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             string failureMessage = "Expected property " +
                                     GetDescriptionFor(Subject) +
@@ -37,7 +37,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(Subject.IsVirtual())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(failureMessage);
 
             return new AndConstraint<PropertyInfoAssertions>(this);
@@ -50,15 +50,15 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<PropertyInfoAssertions> BeWritable(
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CanWrite)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:property} {0} to have a setter{reason}.",
                     Subject);
@@ -74,14 +74,14 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<PropertyInfoAssertions> BeWritable(CSharpAccessModifier accessModifier, string because = "", params object[] reasonArgs)
+        public AndConstraint<PropertyInfoAssertions> BeWritable(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
-            Subject.Should().BeWritable(because, reasonArgs);
+            Subject.Should().BeWritable(because, becauseArgs);
 
-            Subject.GetSetMethod(true).Should().HaveAccessModifier(accessModifier, because, reasonArgs);
+            Subject.GetSetMethod(true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -93,15 +93,15 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<PropertyInfoAssertions> NotBeWritable(
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.CanWrite)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:property} {0} not to have a setter{reason}.",
                     Subject);
@@ -116,13 +116,13 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<PropertyInfoAssertions> BeReadable(string because = "", params object[] reasonArgs)
+        public AndConstraint<PropertyInfoAssertions> BeReadable(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion.ForCondition(Subject.CanRead)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected property " + Subject.Name + " to have a getter{reason}, but it does not.");
 
             return new AndConstraint<PropertyInfoAssertions>(this);
@@ -136,14 +136,14 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<PropertyInfoAssertions> BeReadable(CSharpAccessModifier accessModifier, string because = "", params object[] reasonArgs)
+        public AndConstraint<PropertyInfoAssertions> BeReadable(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
-            Subject.Should().BeReadable(because, reasonArgs);
+            Subject.Should().BeReadable(because, becauseArgs);
 
-            Subject.GetGetMethod(true).Should().HaveAccessModifier(accessModifier, because, reasonArgs);
+            Subject.GetGetMethod(true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -155,15 +155,15 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<PropertyInfoAssertions> NotBeReadable(
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.CanRead)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:property} {0} not to have a getter{reason}.",
                     Subject);
@@ -179,14 +179,14 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<PropertyInfoAssertions> Return(Type propertyType,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
             Execute.Assertion.ForCondition(Subject.PropertyType == propertyType)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected Type of property " + Subject.Name + " to be {0}{reason}, but it is {1}.", propertyType, Subject.PropertyType);
 
 
@@ -201,12 +201,12 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] reasonArgs)
+        public AndConstraint<PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] becauseArgs)
         {
-            return Return(typeof(TReturn), because, reasonArgs);
+            return Return(typeof(TReturn), because, becauseArgs);
         }
 
         internal static string GetDescriptionFor(PropertyInfo property)

--- a/Src/Core/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/Core/Types/PropertyInfoSelectorAssertions.cs
@@ -35,10 +35,10 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<PropertyInfoSelectorAssertions> BeVirtual(string because = "", params object[] reasonArgs)
+        public AndConstraint<PropertyInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs)
         {
             IEnumerable<PropertyInfo> nonVirtualProperties = GetAllNonVirtualPropertiesFromSelection();
 
@@ -48,7 +48,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(!nonVirtualProperties.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(failureMessage);
 
             return new AndConstraint<PropertyInfoSelectorAssertions>(this);
@@ -61,10 +61,10 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<PropertyInfoSelectorAssertions> BeWritable(string because = "", params object[] reasonArgs)
+        public AndConstraint<PropertyInfoSelectorAssertions> BeWritable(string because = "", params object[] becauseArgs)
         {
             PropertyInfo[] readOnlyProperties = GetAllReadOnlyPropertiesFromSelection();
 
@@ -74,7 +74,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(!readOnlyProperties.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(failureMessage);
 
             return new AndConstraint<PropertyInfoSelectorAssertions>(this);
@@ -102,10 +102,10 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] reasonArgs)
+        public AndConstraint<PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
             IEnumerable<PropertyInfo> propertiesWithoutAttribute = GetPropertiesWithout<TAttribute>();
@@ -116,7 +116,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(!propertiesWithoutAttribute.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(failureMessage, typeof(TAttribute));
 
             return new AndConstraint<PropertyInfoSelectorAssertions>(this);

--- a/Src/Core/Types/TypeAssertions.cs
+++ b/Src/Core/Types/TypeAssertions.cs
@@ -31,12 +31,12 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TypeAssertions> Be<TExpected>(string because = "", params object[] reasonArgs)
+        public AndConstraint<TypeAssertions> Be<TExpected>(string because = "", params object[] becauseArgs)
         {
-            return Be(typeof(TExpected), because, reasonArgs);
+            return Be(typeof(TExpected), because, becauseArgs);
         }
 
         /// <summary>
@@ -47,19 +47,19 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TypeAssertions> Be(Type expected, string because = "", params object[] reasonArgs)
+        public AndConstraint<TypeAssertions> Be(Type expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type to be {0}{reason}, but found <null>.", expected);
 
             Execute.Assertion
                 .ForCondition(Subject == expected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(GetFailureMessageIfTypesAreDifferent(Subject, expected));
 
             return new AndConstraint<TypeAssertions>(this);
@@ -70,13 +70,13 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="T">The type to which instances of the type should be assignable.</typeparam>
         /// <param name="because">The reason why instances of the type should be assignable to the type.</param>
-        /// <param name="reasonArgs">The parameters used when formatting the <paramref name="because"/>.</param>
+        /// <param name="becauseArgs">The parameters used when formatting the <paramref name="because"/>.</param>
         /// <returns>An <see cref="AndConstraint{T}"/> which can be used to chain assertions.</returns>
-        public new AndConstraint<TypeAssertions> BeAssignableTo<T>(string because = "", params object[] reasonArgs)
+        public new AndConstraint<TypeAssertions> BeAssignableTo<T>(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(typeof(T).IsAssignableFrom(Subject))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:" + Context + "} {0} to be assignable to {1}{reason}, but it is not",
                     Subject,
@@ -119,12 +119,12 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TypeAssertions> NotBe<TUnexpected>(string because = "", params object[] reasonArgs)
+        public AndConstraint<TypeAssertions> NotBe<TUnexpected>(string because = "", params object[] becauseArgs)
         {
-            return NotBe(typeof(TUnexpected), because, reasonArgs);
+            return NotBe(typeof(TUnexpected), because, becauseArgs);
         }
 
         /// <summary>
@@ -135,14 +135,14 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TypeAssertions> NotBe(Type unexpected, string because = "", params object[] reasonArgs)
+        public AndConstraint<TypeAssertions> NotBe(Type unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject != unexpected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type not to be [" + unexpected.AssemblyQualifiedName + "]{reason}, but it is.");
 
             return new AndConstraint<TypeAssertions>(this);
@@ -155,15 +155,15 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TypeAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] reasonArgs)
+        public AndConstraint<TypeAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
             Execute.Assertion
                 .ForCondition(Subject.IsDecoratedWith<TAttribute>())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to be decorated with {1}{reason}, but the attribute was not found.",
                     Subject, typeof (TAttribute));
 
@@ -181,18 +181,18 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TypeAssertions> BeDecoratedWith<TAttribute>(
-            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] reasonArgs)
+            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            BeDecoratedWith<TAttribute>(because, reasonArgs);
+            BeDecoratedWith<TAttribute>(because, becauseArgs);
 
             Execute.Assertion
                 .ForCondition(Subject.HasMatchingAttribute(isMatchingAttributePredicate))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to be decorated with {1} that matches {2}{reason}, but no matching attribute was found.",
                     Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
 
@@ -205,8 +205,8 @@ namespace FluentAssertions.Types
         /// <param name="interfaceType">The interface that should be implemented.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> Implement(Type interfaceType, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> Implement(Type interfaceType, string because = "", params object[] becauseArgs)
         {
             if (!interfaceType.GetTypeInfo().IsInterface)
             {
@@ -214,7 +214,7 @@ namespace FluentAssertions.Types
             }
 
             Execute.Assertion.ForCondition(Subject.GetInterfaces().Contains(interfaceType))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to implement interface {1}{reason}, but it does not.", Subject, interfaceType);
 
             return new AndConstraint<TypeAssertions>(this);
@@ -226,10 +226,10 @@ namespace FluentAssertions.Types
         /// <typeparam name="TInterface">The interface that should be implemented.</typeparam>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> Implement<TInterface>(string because = "", params object[] reasonArgs) where TInterface : class
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs) where TInterface : class
         {
-            return Implement(typeof (TInterface), because, reasonArgs); 
+            return Implement(typeof (TInterface), because, becauseArgs); 
         }
 
         /// <summary>
@@ -238,8 +238,8 @@ namespace FluentAssertions.Types
         /// <param name="interfaceType">The interface that should be not implemented.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> NotImplement(Type interfaceType, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotImplement(Type interfaceType, string because = "", params object[] becauseArgs)
         {
             if (!interfaceType.GetTypeInfo().IsInterface)
             {
@@ -247,7 +247,7 @@ namespace FluentAssertions.Types
             }
 
             Execute.Assertion.ForCondition(!Subject.GetInterfaces().Contains(interfaceType))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to not implement interface {1}{reason}, but it does.", Subject, interfaceType);
 
             return new AndConstraint<TypeAssertions>(this);
@@ -259,10 +259,10 @@ namespace FluentAssertions.Types
         /// <typeparam name="TInterface">The interface that should not be implemented.</typeparam>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> NotImplement<TInterface>(string because = "", params object[] reasonArgs) where TInterface : class
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs) where TInterface : class
         {
-            return NotImplement(typeof(TInterface), because, reasonArgs);
+            return NotImplement(typeof(TInterface), because, becauseArgs);
         }
 
         /// <summary>
@@ -271,8 +271,8 @@ namespace FluentAssertions.Types
         /// <param name="baseType">The Type that should be derived from.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> BeDerivedFrom(Type baseType, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> BeDerivedFrom(Type baseType, string because = "", params object[] becauseArgs)
         {
             if (baseType.GetTypeInfo().IsInterface)
             {
@@ -280,7 +280,7 @@ namespace FluentAssertions.Types
             }
 
             Execute.Assertion.ForCondition(Subject.IsSubclassOf(baseType))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to be derived from {1}{reason}, but it is not.", Subject, baseType);
 
             return new AndConstraint<TypeAssertions>(this);
@@ -292,10 +292,10 @@ namespace FluentAssertions.Types
         /// <typeparam name="TBaseClass">The Type that should be derived from.</typeparam>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] reasonArgs) where TBaseClass : class
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs) where TBaseClass : class
         {
-            return BeDerivedFrom(typeof(TBaseClass), because, reasonArgs);
+            return BeDerivedFrom(typeof(TBaseClass), because, becauseArgs);
         }
 
         /// <summary>
@@ -303,10 +303,10 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
         /// <param name="propertyType">The type of the property.</param>
         /// <param name="name">The name of the property.</param>
-        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty(Type propertyType, string name, string because = "", params object[] reasonArgs)
+        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty(Type propertyType, string name, string because = "", params object[] becauseArgs)
         {
             PropertyInfo propertyInfo = Subject.GetPropertyByName(name);
 
@@ -318,12 +318,12 @@ namespace FluentAssertions.Types
             }
 
             Execute.Assertion.ForCondition(propertyInfo != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(String.Format("Expected {0} {1}.{2} to exist{{reason}}, but it does not.",
                     propertyType.Name, Subject.FullName, name));
 
             Execute.Assertion.ForCondition(propertyInfo.PropertyType == propertyType)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(String.Format("Expected {0} to be of type {1}{{reason}}, but it is not.",
                     propertyInfoDescription, propertyType));
 
@@ -337,10 +337,10 @@ namespace FluentAssertions.Types
         /// <param name="name">The name of the property.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs)
         {
-            return HaveProperty(typeof(TProperty), name, because, reasonArgs);
+            return HaveProperty(typeof(TProperty), name, because, becauseArgs);
         }
 
         /// <summary>
@@ -349,8 +349,8 @@ namespace FluentAssertions.Types
         /// <param name="name">The name of the property.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> NotHaveProperty(string name, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs)
         {
             PropertyInfo propertyInfo = Subject.GetPropertyByName(name);
 
@@ -362,7 +362,7 @@ namespace FluentAssertions.Types
             }
 
             Execute.Assertion.ForCondition(propertyInfo == null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected {0} to not exist{{reason}}, but it does.", propertyInfoDescription));
 
             return new AndConstraint<TypeAssertions>(this);
@@ -376,15 +376,15 @@ namespace FluentAssertions.Types
         /// <param name="name">The name of the property.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///     is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> HaveExplicitProperty(Type interfaceType, string name, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> HaveExplicitProperty(Type interfaceType, string name, string because = "", params object[] becauseArgs)
         {
-            Subject.Should().Implement(interfaceType, because, reasonArgs);
+            Subject.Should().Implement(interfaceType, because, becauseArgs);
 
             var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
                 
             Execute.Assertion.ForCondition(explicitlyImplementsProperty)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(String.Format("Expected {0} to explicitly implement {1}.{2}{{reason}}, but it does not.",
                     Subject.FullName, interfaceType.FullName, name));
 
@@ -399,10 +399,10 @@ namespace FluentAssertions.Types
         /// <param name="name">The name of the property.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///     is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] reasonArgs) where TInterface : class
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs) where TInterface : class
         {
-            return HaveExplicitProperty(typeof (TInterface), name, because, reasonArgs);
+            return HaveExplicitProperty(typeof (TInterface), name, because, becauseArgs);
         }
 
         /// <summary>
@@ -413,15 +413,15 @@ namespace FluentAssertions.Types
         /// <param name="name">The name of the property.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///     is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> NotHaveExplicitProperty(Type interfaceType, string name, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotHaveExplicitProperty(Type interfaceType, string name, string because = "", params object[] becauseArgs)
         {
-            Subject.Should().Implement(interfaceType, because, reasonArgs);
+            Subject.Should().Implement(interfaceType, because, becauseArgs);
 
             var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
 
             Execute.Assertion.ForCondition(!explicitlyImplementsProperty)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(String.Format("Expected {0} to not explicitly implement {1}.{2}{{reason}}, but it does.",
                     Subject.FullName, interfaceType.FullName, name));
 
@@ -436,10 +436,10 @@ namespace FluentAssertions.Types
         /// <param name="name">The name of the property.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///     is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] reasonArgs) where TInterface : class
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs) where TInterface : class
         {
-            return NotHaveExplicitProperty(typeof(TInterface), name, because, reasonArgs);
+            return NotHaveExplicitProperty(typeof(TInterface), name, because, becauseArgs);
         }
 
         /// <summary>
@@ -451,15 +451,15 @@ namespace FluentAssertions.Types
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///     is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> HaveExplicitMethod(Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> HaveExplicitMethod(Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
-            Subject.Should().Implement(interfaceType, because, reasonArgs);
+            Subject.Should().Implement(interfaceType, because, becauseArgs);
 
             var explicitlyImplementsMethod = Subject.HasMethod(string.Format("{0}.{1}", interfaceType.FullName, name), parameterTypes);
 
             Execute.Assertion.ForCondition(explicitlyImplementsMethod)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(String.Format("Expected {0} to explicitly implement {1}.{2}{{reason}}, but it does not.",
                     Subject.FullName, interfaceType.FullName, name));
 
@@ -475,10 +475,10 @@ namespace FluentAssertions.Types
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
         /// /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///     is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> HaveExplicitMethod<TInterface>(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] reasonArgs) where TInterface : class
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> HaveExplicitMethod<TInterface>(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs) where TInterface : class
         {
-            return HaveExplicitMethod(typeof(TInterface), name, parameterTypes, because, reasonArgs);
+            return HaveExplicitMethod(typeof(TInterface), name, parameterTypes, because, becauseArgs);
         }
 
         /// <summary>
@@ -490,15 +490,15 @@ namespace FluentAssertions.Types
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///     is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> NotHaveExplicitMethod(Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotHaveExplicitMethod(Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
-            Subject.Should().Implement(interfaceType, because, reasonArgs);
+            Subject.Should().Implement(interfaceType, because, becauseArgs);
 
             var explicitlyImplementsMethod = Subject.HasMethod(string.Format("{0}.{1}", interfaceType.FullName, name), parameterTypes);
 
             Execute.Assertion.ForCondition(!explicitlyImplementsMethod)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(String.Format("Expected {0} to not explicitly implement {1}.{2}{{reason}}, but it does.",
                     Subject.FullName, interfaceType.FullName, name));
 
@@ -514,10 +514,10 @@ namespace FluentAssertions.Types
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
         /// /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///     is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] reasonArgs) where TInterface : class
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs) where TInterface : class
         {
-            return NotHaveExplicitMethod(typeof(TInterface), name, parameterTypes, because, reasonArgs);
+            return NotHaveExplicitMethod(typeof(TInterface), name, parameterTypes, because, becauseArgs);
         }
 
         /// <summary>
@@ -528,8 +528,8 @@ namespace FluentAssertions.Types
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveIndexer(Type indexerType, IEnumerable<Type> parameterTypes, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveIndexer(Type indexerType, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
 
@@ -541,13 +541,13 @@ namespace FluentAssertions.Types
             }
 
             Execute.Assertion.ForCondition(propertyInfo != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(String.Format("Expected {0} {1}[{2}] to exist{{reason}}, but it does not.",
                     indexerType.Name, Subject.FullName,
                     GetParameterString(parameterTypes)));
 
             Execute.Assertion.ForCondition(propertyInfo.PropertyType == indexerType)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(String.Format("Expected {0} to be of type {1}{{reason}}, but it is not.",
                     propertyInfoDescription, indexerType));
 
@@ -559,14 +559,14 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
         /// <param name="parameterTypes">The expected indexer's parameter types.</param>
-        public AndConstraint<TypeAssertions> NotHaveIndexer(IEnumerable<Type> parameterTypes, string because = "", params object[] reasonArgs)
+        public AndConstraint<TypeAssertions> NotHaveIndexer(IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
 
             Execute.Assertion.ForCondition(propertyInfo == null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(String.Format("Expected indexer {0}[{1}] to not exist{{reason}}, but it does.",
                     Subject.FullName,
                     GetParameterString(parameterTypes)));
@@ -579,16 +579,15 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        /// <param name="indexerType">The type of the indexer.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
-        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveMethod(String name, IEnumerable<Type> parameterTypes, string because = "", params object[] reasonArgs)
+        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveMethod(String name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
 
             Execute.Assertion.ForCondition(methodInfo != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(String.Format("Expected method {0}.{1}({2}) to exist{{reason}}, but it does not.",
                     Subject.FullName, name,
                     GetParameterString(parameterTypes)));
@@ -604,8 +603,8 @@ namespace FluentAssertions.Types
         /// <param name="parameterTypes">The method parameter types.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndConstraint<TypeAssertions> NotHaveMethod(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotHaveMethod(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
 
@@ -617,7 +616,7 @@ namespace FluentAssertions.Types
             }
 
             Execute.Assertion.ForCondition(methodInfo == null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected method {0}({1}) to not exist{{reason}}, but it does.", methodInfoDescription,
                     GetParameterString(parameterTypes)));
 
@@ -629,15 +628,14 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        /// <param name="indexerType">The type of the indexer.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
-        public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveConstructor(IEnumerable<Type> parameterTypes, string because = "", params object[] reasonArgs)
+        public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveConstructor(IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             ConstructorInfo constructorInfo = Subject.GetConstructor(parameterTypes);
 
             Execute.Assertion.ForCondition(constructorInfo != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(String.Format("Expected constructor {0}({1}) to exist{{reason}}, but it does not.",
                     Subject.FullName,
                     GetParameterString(parameterTypes)));
@@ -650,10 +648,10 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs)
         {
-            return HaveConstructor(new Type[] {}, because, reasonArgs);
+            return HaveConstructor(new Type[] {}, because, becauseArgs);
         }
 
         private string GetParameterString(IEnumerable<Type> parameterTypes)
@@ -674,14 +672,14 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<Type> HaveAccessModifier(
-            CSharpAccessModifier accessModifier, string because = "", params object[] reasonArgs)
+            CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion.ForCondition(accessModifier == Subject.GetCSharpAccessModifier())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type " + Subject.Name + " to be {0}{reason}, but it is {1}.",
                     accessModifier, Subject.GetCSharpAccessModifier());
 

--- a/Src/Core/Types/TypeSelectorAssertions.cs
+++ b/Src/Core/Types/TypeSelectorAssertions.cs
@@ -36,10 +36,10 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] reasonArgs)
+        public AndConstraint<TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
             IEnumerable<Type> typesWithoutAttribute = Subject
@@ -48,7 +48,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(!typesWithoutAttribute.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected all types to be decorated with {0}{reason}," +
                     " but the attribute was not found on the following types:\r\n" + GetDescriptionsFor(typesWithoutAttribute),
                     typeof(TAttribute));
@@ -67,11 +67,11 @@ namespace FluentAssertions.Types
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<TypeSelectorAssertions> BeDecoratedWith<TAttribute>(
-            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] reasonArgs)
+            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
             IEnumerable<Type> typesWithoutMatchingAttribute = Subject
@@ -80,7 +80,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion
                 .ForCondition(!typesWithoutMatchingAttribute.Any())
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected all types to be decorated with {0} that matches {1}{reason}," +
                     " but no matching attribute was found on the following types:\r\n" + GetDescriptionsFor(typesWithoutMatchingAttribute),
                     typeof(TAttribute), isMatchingAttributePredicate.Body);

--- a/Src/FluentAssertions.Net40/EventSourceExtensions.cs
+++ b/Src/FluentAssertions.Net40/EventSourceExtensions.cs
@@ -36,7 +36,7 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         /// <remarks>
@@ -44,14 +44,14 @@ namespace FluentAssertions
         /// subscribe for the events of the object.
         /// </remarks>
         public static EventRecorder ShouldRaise(
-            this object eventSource, string eventName, string because, params object[] reasonArgs)
+            this object eventSource, string eventName, string because, params object[] becauseArgs)
         {
             EventRecorder eventRecorder = eventSource.GetRecorderForEvent(eventName);
 
             if (!eventRecorder.Any())
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected object {0} to raise event {1}{reason}, but it did not.", eventSource, eventName);
             }
 
@@ -85,7 +85,7 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         /// <remarks>
@@ -93,13 +93,13 @@ namespace FluentAssertions
         /// subscribe for the events of the object.
         /// </remarks>
         public static void ShouldNotRaise(
-            this object eventSource, string eventName, string because, params object[] reasonArgs)
+            this object eventSource, string eventName, string because, params object[] becauseArgs)
         {
             EventRecorder eventRecorder = eventSource.GetRecorderForEvent(eventName);
             if (eventRecorder.Any())
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected object {0} to not raise event {1}{reason}, but it did.", eventSource, eventName);
             }
         }

--- a/Src/FluentAssertions.Net40/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions.Net40/ObjectAssertionsExtensions.cs
@@ -19,13 +19,13 @@ namespace FluentAssertions
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public static AndConstraint<ObjectAssertions> BeBinarySerializable(this ObjectAssertions assertions, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
-            return BeBinarySerializable<object>(assertions, options => options, because, reasonArgs);
+            return BeBinarySerializable<object>(assertions, options => options, because, becauseArgs);
         }
 
         /// <summary>
@@ -36,12 +36,12 @@ namespace FluentAssertions
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public static AndConstraint<ObjectAssertions> BeBinarySerializable<T>(this ObjectAssertions assertions,
             Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> options, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             try
             {
@@ -55,7 +55,7 @@ namespace FluentAssertions
             catch (Exception exc)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:\r\n\r\n{1}",
                         assertions.Subject,
                         exc.Message);
@@ -82,11 +82,11 @@ namespace FluentAssertions
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public static AndConstraint<ObjectAssertions> BeXmlSerializable(this ObjectAssertions assertions, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             try
             {
@@ -98,7 +98,7 @@ namespace FluentAssertions
             catch (Exception exc)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:\r\n\r\n{1}",
                         assertions.Subject,
                         exc.Message);

--- a/Src/Shared/AssertionExtensions.Actions.cs
+++ b/Src/Shared/AssertionExtensions.Actions.cs
@@ -24,14 +24,14 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         /// <returns>
         /// Returns an object that allows asserting additional members of the thrown exception.
         /// </returns>
         public static ExceptionAssertions<TException> ShouldThrowExactly<TException>(this Action action, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
             where TException : Exception
         {
             var exceptionAssertions = action.ShouldThrow<TException>();
@@ -50,14 +50,14 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         /// <returns>
         /// Returns an object that allows asserting additional members of the thrown exception.
         /// </returns>
         public static ExceptionAssertions<TException> ShouldThrowExactly<TException>(this Func<Task> asyncAction, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
             where TException : Exception
         {
             var exceptionAssertions = asyncAction.ShouldThrow<TException>();
@@ -76,17 +76,17 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         /// <returns>
         /// Returns an object that allows asserting additional members of the thrown exception.
         /// </returns>
         public static ExceptionAssertions<TException> ShouldThrow<TException>(this Action action, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
             where TException : Exception
         {
-            return new ActionAssertions(action, extractor).ShouldThrow<TException>(because, reasonArgs);
+            return new ActionAssertions(action, extractor).ShouldThrow<TException>(because, becauseArgs);
         }
 
         /// <summary>
@@ -100,13 +100,13 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public static void ShouldNotThrow<TException>(this Action action, string because = "", params object[] reasonArgs)
+        public static void ShouldNotThrow<TException>(this Action action, string because = "", params object[] becauseArgs)
             where TException : Exception
         {
-            new ActionAssertions(action, extractor).ShouldNotThrow<TException>(because, reasonArgs);
+            new ActionAssertions(action, extractor).ShouldNotThrow<TException>(because, becauseArgs);
         }
 
         /// <summary>
@@ -117,12 +117,12 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public static void ShouldNotThrow(this Action action, string because = "", params object[] reasonArgs)
+        public static void ShouldNotThrow(this Action action, string because = "", params object[] becauseArgs)
         {
-            new ActionAssertions(action, extractor).ShouldNotThrow(because, reasonArgs);
+            new ActionAssertions(action, extractor).ShouldNotThrow(because, becauseArgs);
         }
 
         /// <summary>
@@ -136,17 +136,17 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         /// <returns>
         /// Returns an object that allows asserting additional members of the thrown exception.
         /// </returns>
         public static ExceptionAssertions<TException> ShouldThrow<TException>(this Func<Task> asyncAction, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
             where TException : Exception
         {
-            return new AsyncFunctionAssertions(asyncAction, extractor).ShouldThrow<TException>(because, reasonArgs);
+            return new AsyncFunctionAssertions(asyncAction, extractor).ShouldThrow<TException>(because, becauseArgs);
         }
 
         /// <summary>
@@ -160,12 +160,12 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public static void ShouldNotThrow<TException>(this Func<Task> asyncAction, string because = "", params object[] reasonArgs)
+        public static void ShouldNotThrow<TException>(this Func<Task> asyncAction, string because = "", params object[] becauseArgs)
         {
-            new AsyncFunctionAssertions(asyncAction, extractor).ShouldNotThrow<TException>(because, reasonArgs);
+            new AsyncFunctionAssertions(asyncAction, extractor).ShouldNotThrow<TException>(because, becauseArgs);
         }
 
         /// <summary>
@@ -176,12 +176,12 @@ namespace FluentAssertions
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public static void ShouldNotThrow(this Func<Task> asyncAction, string because = "", params object[] reasonArgs)
+        public static void ShouldNotThrow(this Func<Task> asyncAction, string because = "", params object[] becauseArgs)
         {
-            new AsyncFunctionAssertions(asyncAction, extractor).ShouldNotThrow(because, reasonArgs);
+            new AsyncFunctionAssertions(asyncAction, extractor).ShouldNotThrow(because, becauseArgs);
         }
 
         private class AggregateExceptionExtractor : IExtractExceptions

--- a/Src/Shared/AssertionExtensions.cs
+++ b/Src/Shared/AssertionExtensions.cs
@@ -497,13 +497,13 @@ namespace FluentAssertions
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the 
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public static void ShouldAllBeEquivalentTo<T>(this IEnumerable<T> subject, IEnumerable expectation,
-            string because = "", params object[] reasonArgs)
+            string because = "", params object[] becauseArgs)
         {
-            subject.ShouldAllBeEquivalentTo(expectation, options => options, because, reasonArgs);
+            subject.ShouldAllBeEquivalentTo(expectation, options => options, because, becauseArgs);
         }
 
         /// <summary>
@@ -526,12 +526,12 @@ namespace FluentAssertions
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the 
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public static void ShouldAllBeEquivalentTo<T>(this IEnumerable<T> subject, IEnumerable expectation,
             Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> config, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             EquivalencyAssertionOptions<IEnumerable<T>> source = config(AssertionOptions.CloneDefaults<T>()).AsCollection();
 
@@ -541,8 +541,8 @@ namespace FluentAssertions
                 Expectation = expectation,
                 RootIsCollection = true,
                 CompileTimeType = typeof (IEnumerable<T>),
-                Reason = because,
-                ReasonArgs = reasonArgs
+                Because = because,
+                BecauseArgs = becauseArgs
             };
 
             new EquivalencyValidator(source).AssertEquality(context);
@@ -562,13 +562,13 @@ namespace FluentAssertions
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the 
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public static void ShouldBeEquivalentTo<T>(this T subject, object expectation, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
-            ShouldBeEquivalentTo(subject, expectation, config => config, because, reasonArgs);
+            ShouldBeEquivalentTo(subject, expectation, config => config, because, becauseArgs);
         }
 
         /// <summary>
@@ -590,20 +590,20 @@ namespace FluentAssertions
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the 
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public static void ShouldBeEquivalentTo<T>(this T subject, object expectation,
             Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> config, string because = "",
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             var context = new EquivalencyValidationContext
             {
                 Subject = subject,
                 Expectation = expectation,
                 CompileTimeType = typeof (T),
-                Reason = because,
-                ReasonArgs = reasonArgs
+                Because = because,
+                BecauseArgs = becauseArgs
             };
 
             new EquivalencyValidator(config(AssertionOptions.CloneDefaults<T>())).AssertEquality(context);

--- a/Src/Shared/Specialized/AssemblyAssertions.cs
+++ b/Src/Shared/Specialized/AssemblyAssertions.cs
@@ -41,10 +41,10 @@ namespace FluentAssertions.Reflection
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void NotReference(Assembly assembly, string because, params string[] reasonArgs)
+        public void NotReference(Assembly assembly, string because, params string[] becauseArgs)
         {
             var subjectName = Subject.GetName().Name;
             var assemblyName = assembly.GetName().Name;
@@ -52,7 +52,7 @@ namespace FluentAssertions.Reflection
             var references = Subject.GetReferencedAssemblies().Select(x => x.Name);
 
             Execute.Assertion
-                   .BecauseOf(because, reasonArgs)
+                   .BecauseOf(because, becauseArgs)
                    .ForCondition(references.All(x => x != assemblyName))
                    .FailWith("Assembly {0} should not reference assembly {1}{reason}", subjectName, assemblyName);
         }
@@ -74,10 +74,10 @@ namespace FluentAssertions.Reflection
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void Reference(Assembly assembly, string because, params string[] reasonArgs)
+        public void Reference(Assembly assembly, string because, params string[] becauseArgs)
         {
             var subjectName = Subject.GetName().Name;
             var assemblyName = assembly.GetName().Name;
@@ -85,7 +85,7 @@ namespace FluentAssertions.Reflection
             var references = Subject.GetReferencedAssemblies().Select(x => x.Name);
 
             Execute.Assertion
-                   .BecauseOf(because, reasonArgs)
+                   .BecauseOf(because, becauseArgs)
                    .ForCondition(references.Any(x => x == assemblyName))
                    .FailWith("Assembly {0} should reference assembly {1}{reason}, but it does not", subjectName, assemblyName);
         }
@@ -97,8 +97,8 @@ namespace FluentAssertions.Reflection
         /// <param name="name">The name of the class.</param>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="reasonArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
-        public AndWhichConstraint<AssemblyAssertions, Type> DefineType(string @namespace, string name, string because = "", params object[] reasonArgs)
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndWhichConstraint<AssemblyAssertions, Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs)
         {
 #if !NETFX_CORE && !WINRT
             var foundType = Subject.GetTypes().SingleOrDefault(t => t.Namespace == @namespace && t.Name == name);
@@ -107,7 +107,7 @@ namespace FluentAssertions.Reflection
             var foundType = typeInfo == null ? null : typeInfo.AsType();
 #endif
             Execute.Assertion.ForCondition(foundType != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected assembly {0} to define type {1}.{2}, but it does not.", Subject.FullName,
                     @namespace, name);
 

--- a/Src/Shared/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/Shared/Specialized/ExecutionTimeAssertions.cs
@@ -41,15 +41,15 @@ namespace FluentAssertions.Specialized
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public void ShouldNotExceed(TimeSpan maxDuration, string because = "", params object[] reasonArgs)
+        public void ShouldNotExceed(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
         {
             if (executionTime > maxDuration)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Execution of " + ActionDescription + " should not exceed {0}{reason}, but it required {1}",
                         maxDuration, executionTime);
             }

--- a/Src/Shared/Xml/XAttributeAssertions.cs
+++ b/Src/Shared/Xml/XAttributeAssertions.cs
@@ -36,14 +36,14 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XAttributeAssertions> Be(XAttribute expected, string because, params object [] reasonArgs)
+        public AndConstraint<XAttributeAssertions> Be(XAttribute expected, string because, params object [] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Name.Equals(expected.Name) && Subject.Value.Equals(expected.Value))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML attribute to be {0}{reason}, but found {1}", expected, Subject);
 
             return new AndConstraint<XAttributeAssertions>(this);
@@ -68,14 +68,14 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XAttributeAssertions> NotBe(XAttribute unexpected, string because, params object [] reasonArgs)
+        public AndConstraint<XAttributeAssertions> NotBe(XAttribute unexpected, string because, params object [] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.Name.Equals(unexpected.Name) || !Subject.Value.Equals(unexpected.Value))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect XML attribute to be {0}{reason}.", unexpected);
 
             return new AndConstraint<XAttributeAssertions>(this);
@@ -99,14 +99,14 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XAttributeAssertions> HaveValue(string expected, string because, params object[] reasonArgs)
+        public AndConstraint<XAttributeAssertions> HaveValue(string expected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Value == expected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML attribute '{0}' to have value {1}{reason}, but found {2}.",
                     Subject.Name, expected, Subject.Value);
 

--- a/Src/Shared/Xml/XDocumentAssertions.cs
+++ b/Src/Shared/Xml/XDocumentAssertions.cs
@@ -41,14 +41,14 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XDocumentAssertions> Be(XDocument expected, string because, params object[] reasonArgs)
+        public AndConstraint<XDocumentAssertions> Be(XDocument expected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.IsSameOrEqualTo(expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML document to be {0}{reason}, but found {1}", expected, Subject);
 
             return new AndConstraint<XDocumentAssertions>(this);
@@ -73,19 +73,19 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XDocumentAssertions> NotBe(XDocument unexpected, string because, params object[] reasonArgs)
+        public AndConstraint<XDocumentAssertions> NotBe(XDocument unexpected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect XML document to be {0}, but found <null>.", unexpected);
 
             Execute.Assertion
                 .ForCondition(!Subject.Equals(unexpected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect XML document to be {0}{reason}.", unexpected);
 
             return new AndConstraint<XDocumentAssertions>(this);
@@ -110,14 +110,14 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XDocumentAssertions> BeEquivalentTo(XDocument expected, string because, params object[] reasonArgs)
+        public AndConstraint<XDocumentAssertions> BeEquivalentTo(XDocument expected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(XNode.DeepEquals(Subject, expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML document {0} to be equivalent to {1}{reason}.",
                     Subject, expected);
 
@@ -143,14 +143,14 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XDocumentAssertions> NotBeEquivalentTo(XDocument unexpected, string because, params object[] reasonArgs)
+        public AndConstraint<XDocumentAssertions> NotBeEquivalentTo(XDocument unexpected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!XNode.DeepEquals(Subject, unexpected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect XML document {0} to be equivalent to {1}{reason}.",
                     Subject, unexpected);
 
@@ -186,11 +186,11 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndWhichConstraint<XDocumentAssertions, XElement> HaveRoot(string expected, string because,
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -198,7 +198,7 @@ namespace FluentAssertions.Xml
                     "Cannot assert the document has a root element if the element name is <null>*");
             }
 
-            return HaveRoot(XNamespace.None + expected, because, reasonArgs);
+            return HaveRoot(XNamespace.None + expected, because, becauseArgs);
         }
 
         /// <summary>
@@ -210,10 +210,10 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndWhichConstraint<XDocumentAssertions, XElement> HaveRoot(XName expected, string because, params object[] reasonArgs)
+        public AndWhichConstraint<XDocumentAssertions, XElement> HaveRoot(XName expected, string because, params object[] becauseArgs)
         {
             if (Subject == null)
             {
@@ -231,7 +231,7 @@ namespace FluentAssertions.Xml
 
             Execute.Assertion
                 .ForCondition((root != null) && (root.Name == expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML document to have root element \"" + expected.ToString().Escape(escapePlaceholders: true) + "\"{reason}" +
                           ", but found {0}.", Subject);
 
@@ -273,11 +273,11 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndWhichConstraint<XDocumentAssertions, XElement> HaveElement(string expected, string because,
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (expected == null)
             {
@@ -285,7 +285,7 @@ namespace FluentAssertions.Xml
                     "Cannot assert the document has an element if the element name is <null>*");
             }
 
-            return HaveElement(XNamespace.None + expected, because, reasonArgs);
+            return HaveElement(XNamespace.None + expected, because, becauseArgs);
         }
 
         /// <summary>
@@ -299,11 +299,11 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndWhichConstraint<XDocumentAssertions, XElement> HaveElement(XName expected, string because,
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             if (Subject == null)
             {
@@ -321,14 +321,14 @@ namespace FluentAssertions.Xml
 
             Execute.Assertion
                 .ForCondition(Subject.Root != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML document {0} to have root element with child \"" + expectedText + "\"{reason}" +
                           ", but XML document has no Root element.", Subject);
 
             XElement xElement = Subject.Root.Element(expected);
             Execute.Assertion
                 .ForCondition(xElement != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML document {0} to have root element with child \"" + expectedText + "\"{reason}" +
                           ", but no such child element was found.", Subject);
 

--- a/Src/Shared/Xml/XElementAssertions.cs
+++ b/Src/Shared/Xml/XElementAssertions.cs
@@ -37,14 +37,14 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XElementAssertions> Be(XElement expected, string because, params object[] reasonArgs)
+        public AndConstraint<XElementAssertions> Be(XElement expected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(XNode.DeepEquals(Subject, expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML element to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<XElementAssertions>(this);
@@ -69,14 +69,14 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XElementAssertions> NotBe(XElement unexpected, string because, params object[] reasonArgs)
+        public AndConstraint<XElementAssertions> NotBe(XElement unexpected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition((ReferenceEquals(Subject, null) && !ReferenceEquals(unexpected, null)) || !XNode.DeepEquals(Subject, unexpected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML element not to be {0}{reason}.", unexpected);
 
             return new AndConstraint<XElementAssertions>(this);
@@ -101,14 +101,14 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XElementAssertions> BeEquivalentTo(XElement expected, string because, params object[] reasonArgs)
+        public AndConstraint<XElementAssertions> BeEquivalentTo(XElement expected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(XNode.DeepEquals(Subject, expected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML element {0} to be equivalent to {1}{reason}.",
                     Subject, expected);
 
@@ -134,14 +134,14 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XElementAssertions> NotBeEquivalentTo(XElement unexpected, string because, params object[] reasonArgs)
+        public AndConstraint<XElementAssertions> NotBeEquivalentTo(XElement unexpected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!XNode.DeepEquals(Subject, unexpected))
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect XML element {0} to be equivalent to {1}{reason}.",
                     Subject, unexpected);
 
@@ -165,14 +165,14 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<XElementAssertions> HaveValue(string expected, string because, params object[] reasonArgs)
+        public AndConstraint<XElementAssertions> HaveValue(string expected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Value == expected)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML element '{0}' to have value {1}{reason}, but found {2}.",
                     Subject.Name, expected, Subject.Value);
 
@@ -211,13 +211,13 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because,
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
-            return HaveAttribute(XNamespace.None + expectedName, expectedValue, because, reasonArgs);
+            return HaveAttribute(XNamespace.None + expectedName, expectedValue, because, becauseArgs);
         }
 
         /// <summary>
@@ -230,25 +230,25 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<XElementAssertions> HaveAttribute(XName expectedName, string expectedValue, string because,
-            params object[] reasonArgs)
+            params object[] becauseArgs)
         {
             XAttribute attribute = Subject.Attribute(expectedName);
             string expectedText = expectedName.ToString().Escape(escapePlaceholders: true);
 
             Execute.Assertion
                 .ForCondition(attribute != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected XML element to have attribute \"" + expectedText + "\" with value {0}{reason}, but found no such attribute in {1}",
                     expectedValue, Subject);
 
             Execute.Assertion
                 .ForCondition(attribute.Value == expectedValue)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected XML attribute \"" + expectedText + "\" to have value {0}{reason}, but found {1}.", expectedValue, attribute.Value);
 
@@ -284,12 +284,12 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndWhichConstraint<XElementAssertions, XElement> HaveElement(string expected, string because, params object[] reasonArgs)
+        public AndWhichConstraint<XElementAssertions, XElement> HaveElement(string expected, string because, params object[] becauseArgs)
         {
-            return HaveElement(XNamespace.None + expected, because, reasonArgs);
+            return HaveElement(XNamespace.None + expected, because, becauseArgs);
         }
 
         /// <summary>
@@ -301,15 +301,15 @@ namespace FluentAssertions.Xml
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name="reasonArgs">
+        /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndWhichConstraint<XElementAssertions, XElement> HaveElement(XName expected, string because, params object[] reasonArgs)
+        public AndWhichConstraint<XElementAssertions, XElement> HaveElement(XName expected, string because, params object[] becauseArgs)
         {
             XElement xElement = Subject.Element(expected);
             Execute.Assertion
                 .ForCondition(xElement != null)
-                .BecauseOf(because, reasonArgs)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML element {0} to have child element \"" + expected.ToString().Escape(escapePlaceholders: true) + "\"{reason}" +
                         ", but no such child element was found.", Subject);
 

--- a/Tests/FluentAssertions.Shared.Specs/AssertionFailureSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/AssertionFailureSpecs.cs
@@ -108,10 +108,10 @@ namespace FluentAssertions.Specs
 
         internal class AssertionsTestSubClass : ReferenceTypeAssertions<object, AssertionsTestSubClass>
         {
-            public void AssertFail(string because, params object [] reasonArgs)
+            public void AssertFail(string because, params object [] becauseArgs)
             {
                 Execute.Assertion
-                    .BecauseOf(because, reasonArgs)
+                    .BecauseOf(because, becauseArgs)
                     .FailWith("Expected it to fail{reason}");
             }
 

--- a/Tests/FluentAssertions.Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/AssertionScopeSpecs.cs
@@ -186,13 +186,13 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => 1.Should().Be(2, "can't use these in reasonArgs: {0} {1}", "{", "}");
+            Action act = () => 1.Should().Be(2, "can't use these in becauseArgs: {0} {1}", "{", "}");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>()
-                .WithMessage("*because can't use these in reasonArgs: { }*");
+                .WithMessage("*because can't use these in becauseArgs: { }*");
         }
 
         [TestMethod]


### PR DESCRIPTION
- Changed all 'ReasonArgs' properties and fields to be named 'BecauseArgs'.
- Changed all 'Reason' properties and fields to be named 'Because'.
- Changed all 'reasonArgs' parameters to be named 'becauseArgs'.
- Fixed some XML-Doc comments.
- It is an additional fix for commit 688184bf8e917756e434708b20cf8005d9c7b501.


For additional information please refer the following issues and pull-requests:
`Rename reason argument in Be() to because.` #28 
`Changes all 'reason' parameters to be named 'because'` #91 