### PR TITLE
Ensured that user equivalency steps run before all the built-in steps.

### DIFF
--- a/Src/Core/EquivalencyStepCollection.cs
+++ b/Src/Core/EquivalencyStepCollection.cs
@@ -105,9 +105,9 @@ namespace FluentAssertions
 
         private static IEnumerable<IEquivalencyStep> GetDefaultSteps()
         {
+            yield return new RunAllUserStepsEquivalencyStep();
             yield return new TryConversionEquivalencyStep();
             yield return new ReferenceEqualityEquivalencyStep();
-            yield return new RunAllUserStepsEquivalencyStep();
             yield return new GenericDictionaryEquivalencyStep();
             yield return new DictionaryEquivalencyStep();
             yield return new MultiDimensionalArrayEquivalencyStep();


### PR DESCRIPTION
Should solve #360.