### PR TITLE
Semantic (Not)BeEquivalent for XDocument/XElement

### DIFF
--- a/Src/FluentAssertions.Net40/Net40.csproj
+++ b/Src/FluentAssertions.Net40/Net40.csproj
@@ -83,7 +83,6 @@
     <Compile Include="Xml\XmlAssertionExtensions.cs" />
     <Compile Include="Xml\XmlNodeAssertions.cs" />
     <Compile Include="Xml\XmlNodeFormatter.cs" />
-    <Compile Include="Xml\XmlReaderValidator.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\FluentAssertions.snk">

--- a/Src/FluentAssertions.Net45/Net45.csproj
+++ b/Src/FluentAssertions.Net45/Net45.csproj
@@ -110,9 +110,6 @@
     <Compile Include="..\FluentAssertions.Net40\Xml\XmlNodeFormatter.cs">
       <Link>Xml\XmlNodeFormatter.cs</Link>
     </Compile>
-    <Compile Include="..\FluentAssertions.Net40\Xml\XmlReaderValidator.cs">
-      <Link>Xml\XmlReaderValidator.cs</Link>
-    </Compile>
     <Compile Include="Execution\XUnit2TestFramework.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Src/Shared/Shared.projitems
+++ b/Src/Shared/Shared.projitems
@@ -26,5 +26,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Xml\XAttributeAssertions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Xml\XDocumentAssertions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Xml\XElementAssertions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xml\XmlReaderValidator.cs" />
   </ItemGroup>
 </Project>

--- a/Src/Shared/Xml/XDocumentAssertions.cs
+++ b/Src/Shared/Xml/XDocumentAssertions.cs
@@ -115,11 +115,7 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XDocumentAssertions> BeEquivalentTo(XDocument expected, string because, params object[] becauseArgs)
         {
-            Execute.Assertion
-                .ForCondition(XNode.DeepEquals(Subject, expected))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML document {0} to be equivalent to {1}{reason}.",
-                    Subject, expected);
+            new XmlReaderValidator(Subject.CreateReader(), expected.CreateReader(), because, becauseArgs).Validate(true);
 
             return new AndConstraint<XDocumentAssertions>(this);
         }
@@ -148,11 +144,7 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XDocumentAssertions> NotBeEquivalentTo(XDocument unexpected, string because, params object[] becauseArgs)
         {
-            Execute.Assertion
-                .ForCondition(!XNode.DeepEquals(Subject, unexpected))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect XML document {0} to be equivalent to {1}{reason}.",
-                    Subject, unexpected);
+            new XmlReaderValidator(Subject.CreateReader(), unexpected.CreateReader(), because, becauseArgs).Validate(false);
 
             return new AndConstraint<XDocumentAssertions>(this);
         }

--- a/Src/Shared/Xml/XElementAssertions.cs
+++ b/Src/Shared/Xml/XElementAssertions.cs
@@ -3,6 +3,7 @@ using System.Xml.Linq;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
+using System.Xml;
 
 namespace FluentAssertions.Xml
 {
@@ -21,7 +22,9 @@ namespace FluentAssertions.Xml
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="XElement"/> equals the <paramref name="expected"/> element.
+        /// Asserts that the current <see cref="XElement"/> equals the 
+        /// <paramref name="expected"/> element, by using 
+        /// <see cref="XElement.DeepEquals(XNode)"/>
         /// </summary>
         /// <param name="expected">The expected element</param>
         public AndConstraint<XElementAssertions> Be(XElement expected)
@@ -30,7 +33,9 @@ namespace FluentAssertions.Xml
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="XElement"/> equals the <paramref name="expected"/> element.
+        /// Asserts that the current <see cref="XElement"/> equals the 
+        /// <paramref name="expected"/> element, by using 
+        /// <see cref="XElement.DeepEquals(XNode)"/>
         /// </summary>
         /// <param name="expected">The expected element</param>
         /// <param name="because">
@@ -51,8 +56,9 @@ namespace FluentAssertions.Xml
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="XElement"/> does not equal the <paramref name="unexpected"/> element,
-        /// using its <see cref="object.Equals(object)" /> implementation.
+        /// Asserts that the current <see cref="XElement"/> does not equal the 
+        /// <paramref name="unexpected"/> element, using 
+        /// <see cref="XElement.DeepEquals(XNode)" />.
         /// </summary>
         /// <param name="unexpected">The unexpected element</param>
         public AndConstraint<XElementAssertions> NotBe(XElement unexpected)
@@ -61,8 +67,9 @@ namespace FluentAssertions.Xml
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="XElement"/> does not equal the <paramref name="unexpected"/> element,
-        /// using its <see cref="object.Equals(object)" /> implementation.
+        /// Asserts that the current <see cref="XElement"/> does not equal the 
+        /// <paramref name="unexpected"/> element, using 
+        /// <see cref="XElement.DeepEquals(XNode)" />.
         /// </summary>
         /// <param name="unexpected">The unexpected element</param>
         /// <param name="because">
@@ -83,18 +90,20 @@ namespace FluentAssertions.Xml
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="XElement"/> is equivalent to the <paramref name="expected"/> element,
-        /// using its <see cref="XNode.DeepEquals()" /> implementation.
+        /// Asserts that the current <see cref="XElement"/> is equivalent to the 
+        /// <paramref name="expected"/> element, using a semantic equivalency
+        /// comparison.
         /// </summary>
         /// <param name="expected">The expected element</param>
         public AndConstraint<XElementAssertions> BeEquivalentTo(XElement expected)
         {
-            return BeEquivalentTo(expected, string.Empty);
+            return  BeEquivalentTo(expected, string.Empty);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="XElement"/> is equivalent to the <paramref name="expected"/> element,
-        /// using its <see cref="XNode.DeepEquals()" /> implementation.
+        /// Asserts that the current <see cref="XElement"/> is equivalent to the 
+        /// <paramref name="expected"/> element, using a semantic equivalency
+        /// comparison.
         /// </summary>
         /// <param name="expected">The expected element</param>
         /// <param name="because">
@@ -106,18 +115,19 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XElementAssertions> BeEquivalentTo(XElement expected, string because, params object[] becauseArgs)
         {
-            Execute.Assertion
-                .ForCondition(XNode.DeepEquals(Subject, expected))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML element {0} to be equivalent to {1}{reason}.",
-                    Subject, expected);
+            using (XmlReader subjectReader = Subject.CreateReader())
+            using (XmlReader expectedReader = expected.CreateReader())
+            {
+                new XmlReaderValidator(subjectReader, expectedReader, because, becauseArgs).Validate(true);
+            }
 
             return new AndConstraint<XElementAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="XElement"/> is not equivalent to the <paramref name="unexpected"/> element,
-        /// using its <see cref="XNode.DeepEquals()" /> implementation.
+        /// Asserts that the current <see cref="XElement"/> is not equivalent to 
+        /// the <paramref name="unexpected"/> element, using a semantic
+        /// equivalency comparison.
         /// </summary>
         /// <param name="unexpected">The unexpected element</param>
         public AndConstraint<XElementAssertions> NotBeEquivalentTo(XElement unexpected)
@@ -126,8 +136,9 @@ namespace FluentAssertions.Xml
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="XElement"/> is not equivalent to the <paramref name="unexpected"/> element,
-        /// using its <see cref="XNode.DeepEquals()" /> implementation.
+        /// Asserts that the current <see cref="XElement"/> is not equivalent to 
+        /// the <paramref name="unexpected"/> element, using a semantic
+        /// equivalency comparison.
         /// </summary>
         /// <param name="unexpected">The unexpected element</param>
         /// <param name="because">
@@ -139,11 +150,7 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XElementAssertions> NotBeEquivalentTo(XElement unexpected, string because, params object[] becauseArgs)
         {
-            Execute.Assertion
-                .ForCondition(!XNode.DeepEquals(Subject, unexpected))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect XML element {0} to be equivalent to {1}{reason}.",
-                    Subject, unexpected);
+            new XmlReaderValidator(Subject.CreateReader(), unexpected.CreateReader(), because, becauseArgs).Validate(false);
 
             return new AndConstraint<XElementAssertions>(this);
         }

--- a/Src/Shared/Xml/XmlReaderValidator.cs
+++ b/Src/Shared/Xml/XmlReaderValidator.cs
@@ -51,7 +51,7 @@ namespace FluentAssertions.Xml
             }
             if(!expectedEquivalence && validationResult == null)
             {
-                assertion.FailWith("Expected Xml to not be equivalent{reason}, but it is.");
+                assertion.FailWith("Did not expect Xml to be equivalent{reason}, but it is.");
             }
         }
 
@@ -79,6 +79,10 @@ namespace FluentAssertions.Xml
                         }
                         locationStack.Push(subjectReader.LocalName);
                         validationResult = ValidateAttributes();
+                        if(subjectReader.IsEmptyElement)
+                        {
+                            locationStack.Pop();
+                        }
                         break;
                     case XmlNodeType.EndElement:
                         // No need to verify end element, if it doesn't match

--- a/Tests/FluentAssertions.Net40.Specs/XmlNodeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Net40.Specs/XmlNodeAssertionSpecs.cs
@@ -11,10 +11,10 @@ namespace FluentAssertions.Specs
     [TestClass]
     public class XmlNodeAssertionSpecs
     {
-        #region Be / NotBe
+        #region BeSameAs / NotBeSameAs
 
         [TestMethod]
-        public void When_asserting_an_XmlNode_is_the_same_as_the_same_XmlNode_it_should_succeed()
+        public void When_asserting_an_xml_node_is_the_same_as_the_same_xml_node_it_should_succeed()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -34,7 +34,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_same_as_a_different_XmlDocument_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -58,7 +58,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_same_as_a_different_XmlDocument_it_should_fail_with_descriptive_message_and_truncate_xml()
+        public void When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message_and_truncate_xml()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -80,12 +80,164 @@ namespace FluentAssertions.Specs
             act.ShouldThrow<AssertFailedException>()
                 .WithMessage("Expected Xml Node to refer to <otherDoc /> because we want to test the failure message, but found <doc>Some very long....");
         }
+
+        [TestMethod]
+        public void When_asserting_the_equality_of_an_xml_node_but_is_null_it_should_throw_appropriately()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            XmlDocument actual = null;
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => actual.Should().BeSameAs(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected XML Node to refer to *xml*, but found <null>.");
+        }
+        #endregion
+
+        #region BeNull / NotBeNull
+
+        [TestMethod]
+        public void When_asserting_an_xml_node_is_null_and_it_is_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            XmlNode node = null;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                node.Should().BeNull();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_node_is_null_but_it_is_not_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml("<xml/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                xmlDoc.Should().BeNull();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_node_is_null_but_it_is_not_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml("<xml/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                xmlDoc.Should().BeNull("because we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected XML Node to be <null> because we want to test the failure message," +
+                    " but found <xml />.");
+        }
+
+        [TestMethod]
+        public void When_asserting_a_non_null_xml_node_is_not_null_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml("<xml/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                xmlDoc.Should().NotBeNull();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_a_null_xml_node_is_not_null_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            XmlDocument xmlDoc = null;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                xmlDoc.Should().NotBeNull();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_a_null_xml_node_is_not_null_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            XmlDocument xmlDoc = null;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                xmlDoc.Should().NotBeNull("because we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected XML Node not to be <null> because we want to test the failure message.");
+        }
+
         #endregion
 
         #region BeEquivalentTo / NotBeEquivalentTo
 
         [TestMethod]
-        public void When_asserting_an_XmlNode_is_equivalent_as_the_same_XmlNode_it_should_succeed()
+        public void When_asserting_an_xml_node_is_equivalent_to_the_same_xml_node_it_should_succeed()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -105,7 +257,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlNode_is_not_equivalent_to_som_other_XmlNode_it_should_succeed()
+        public void When_asserting_an_xml_node_is_not_equivalent_to_som_other_xml_node_it_should_succeed()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -128,7 +280,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlNode_is_not_equivalent_to_same_XmlNode_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_not_equivalent_to_same_xml_node_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -146,11 +298,11 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().
-                WithMessage("Expected Xml to not be equivalent because we want to test the failure message, but it is.");
+                WithMessage("Did not expect Xml to be equivalent because we want to test the failure message, but it is.");
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_a_different_XmlDocument_with_other_contents_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_with_other_contents_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -174,7 +326,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_a_different_XmlDocument_with_same_contents_it_should_succeed()
+        public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_with_same_contents_it_should_succeed()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -199,7 +351,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_assertion_an_XmlDocument_is_equivalent_to_a_different_XmlDocument_with_different_namespace_prefix_it_should_succeed()
+        public void When_assertion_an_xml_node_is_equivalent_to_a_different_xml_node_with_different_namespace_prefix_it_should_succeed()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -220,10 +372,9 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldNotThrow();
         }
-        #endregion
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_a_different_XmlDocument_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
+        public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -246,7 +397,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_a_different_XmlDcoument_which_differs_on_a_child_element_name_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_to_a_different_XmlDcoument_which_differs_on_a_child_element_name_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -270,7 +421,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_a_different_XmlDocument_which_differs_on_a_child_element_namespace_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_on_a_child_element_namespace_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -294,7 +445,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_contains_an_unexpected_node_type_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_an_unexpected_node_type_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -318,7 +469,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_contains_extra_elements_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_extra_elements_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -342,7 +493,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_lacks_elements_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_elements_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -366,7 +517,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_lacks_attributes_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_attributes_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -389,9 +540,8 @@ namespace FluentAssertions.Specs
                 WithMessage("Expected attribute \"a\" at \"/xml/element\" because we want to test the failure message, but found none.");
         }
 
-
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_has_extra_attributes_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_extra_attributes_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -415,7 +565,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -439,7 +589,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -463,7 +613,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_which_has_different_text_contents_it_should_fail_with_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_text_contents_it_should_fail_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -487,7 +637,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_with_different_comments_it_should_succeed()
+        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_with_different_comments_it_should_succeed()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -509,7 +659,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_to_different_XmlDocument_with_different_insignificant_whitespace_it_should_succeed()
+        public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_with_different_insignificant_whitespace_it_should_succeed()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -531,12 +681,12 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_XmlDocument_is_equivalent_that_contains_an_unsupported_node_it_should_throw_a_descriptive_message()
+        public void When_asserting_an_xml_node_is_equivalent_that_contains_an_unsupported_node_it_should_throw_a_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
             //-------------------------------------------------------------------------------------------------------------------
-            var subject = new XmlDocument() { PreserveWhitespace = true };
+            var subject = new XmlDocument();
             subject.LoadXml("<xml><![CDATA[Text]]></xml>");
 
             //-------------------------------------------------------------------------------------------------------------------
@@ -550,5 +700,31 @@ namespace FluentAssertions.Specs
             act.ShouldThrow<NotSupportedException>()
                 .WithMessage("CDATA found at /xml is not supported for equivalency comparison.");
         }
+
+        [TestMethod]
+        public void When_asserting_an_xml_node_is_equivalent_that_isnt_it_should_include_the_right_location_in_the_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = new XmlDocument();
+            subject.LoadXml("<xml><a/><b c=\"d\"/></xml>");
+            var expected = new XmlDocument();
+            expected.LoadXml("<xml><a/><b c=\"e\"/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected attribute \"c\" at \"/xml/b\" to have value \"e\", but found \"d\".");
+        }
+
+        #endregion
+
     }
 }

--- a/Tests/FluentAssertions.Shared.Specs/XDocumentAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/XDocumentAssertionSpecs.cs
@@ -297,8 +297,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>()
-                .WithMessage("Expected XML document <parent>...</parent> to be equivalent to <parent>...</parent>" +
-                    " because we want to test the failure message.");
+                .WithMessage("Expected node of type EndElement at \"/parent\" because we want to test the failure message, but found Element.");
         }
 
         [TestMethod]
@@ -320,8 +319,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>()
-                .WithMessage("Expected XML document <parent>...</parent> to be equivalent to <parent>...</parent>" +
-                    " because we want to test the failure message.");
+                .WithMessage("Expected node of type Element at \"/parent\" because we want to test the failure message, but found EndElement.");
         }
 
         [TestMethod]
@@ -427,8 +425,49 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>()
-                .WithMessage("Did not expect XML document <parent>...</parent> to be equivalent to <parent>...</parent>" +
-                    " because we want to test the failure message.");
+                .WithMessage("Did not expect Xml to be equivalent because we want to test the failure message, but it is.");
+        }
+
+        [TestMethod]
+        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_different_ns_prefixes_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var document = XDocument.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
+            var otherXDocument = XDocument.Parse(@"<parent xmlns:ns2=""a""><ns2:child /></parent>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                document.Should().NotBeEquivalentTo(otherXDocument, "because we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var element = XDocument.Parse(@"<xml xmlns:ns1=""a"" />");
+            var otherXElement = XDocument.Parse(@"<xml />");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().NotBeEquivalentTo(otherXElement);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
         }
 
         [TestMethod]
@@ -450,8 +489,179 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>()
-                .WithMessage("Did not expect XML document <parent>...</parent> to be equivalent to <parent>...</parent>" +
-                    " because we want to test the failure message.");
+                .WithMessage("Did not expect Xml to be equivalent because we want to test the failure message, but it is.");
+        }
+
+        [TestMethod]
+        public void When_assertion_an_xml_document_is_equivalent_to_a_different_xml_document_with_different_namespace_prefix_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XDocument.Parse("<xml xmlns=\"urn:a\"/>");
+            var expected = XDocument.Parse("<a:xml xmlns:a=\"urn:a\"/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_document_is_equivalent_to_a_different_xml_document_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XDocument.Parse("<xml xmlns:a=\"urn:a\"/>");
+            var expected = XDocument.Parse("<xml/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_lacks_attributes_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XDocument.Parse("<xml><element b=\"1\"/></xml>");
+            var expected = XDocument.Parse("<xml><element a=\"b\" b=\"1\"/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected attribute \"a\" at \"/xml/element\" because we want to test the failure message, but found none.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_extra_attributes_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XDocument.Parse("<xml><element a=\"b\"/></xml>");
+            var expected = XDocument.Parse("<xml><element/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Didn't expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XDocument.Parse("<xml><element a=\"b\"/></xml>");
+            var expected = XDocument.Parse("<xml><element a=\"c\"/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected attribute \"a\" at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XDocument.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
+            var expected = XDocument.Parse("<xml><element a=\"b\"/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Didn't expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_text_contents_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XDocument.Parse("<xml>a</xml>");
+            var expected = XDocument.Parse("<xml>b</xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected content to be \"b\" at \"/xml\" because we want to test the failure message, but found \"a\".");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_with_different_comments_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XDocument.Parse("<xml><!--Comment--><a/></xml>");
+            var expected = XDocument.Parse("<xml><a/><!--Comment--></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
         }
 
         #endregion

--- a/Tests/FluentAssertions.Shared.Specs/XElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/XElementAssertionSpecs.cs
@@ -451,8 +451,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>()
-                .WithMessage("Expected XML element <parent>...</parent> to be equivalent to <parent>...</parent>" +
-                    " because we want to test the failure message.");
+                .WithMessage("Expected node of type EndElement at \"/parent\" because we want to test the failure message, but found Element.");
         }
 
         [TestMethod]
@@ -474,8 +473,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>()
-                .WithMessage("Expected XML element <parent>...</parent> to be equivalent to <parent>...</parent>" +
-                    " because we want to test the failure message.");
+                .WithMessage("Expected node of type Element at \"/parent\" because we want to test the failure message, but found EndElement.");
         }
 
         [TestMethod]
@@ -542,6 +540,48 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_different_ns_prefixes_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var element = XElement.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
+            var otherXElement = XElement.Parse(@"<parent xmlns:ns2=""a""><ns2:child /></parent>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().NotBeEquivalentTo(otherXElement);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var element = XElement.Parse(@"<xml xmlns:ns1=""a"" />");
+            var otherXElement = XElement.Parse(@"<xml />");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().NotBeEquivalentTo(otherXElement);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
         public void When_asserting_a_xml_element_is_not_equivalent_to_the_same_xml_element_it_should_fail()
         {
             //-------------------------------------------------------------------------------------------------------------------
@@ -581,8 +621,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>()
-                .WithMessage("Did not expect XML element <parent>...</parent> to be equivalent to <parent>...</parent>" +
-                    " because we want to test the failure message.");
+                .WithMessage("Did not expect Xml to be equivalent because we want to test the failure message, but it is.");
         }
 
         [TestMethod]
@@ -604,8 +643,179 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>()
-                .WithMessage("Did not expect XML element <parent>...</parent> to be equivalent to <parent>...</parent>" +
-                    " because we want to test the failure message.");
+                .WithMessage("Did not expect Xml to be equivalent because we want to test the failure message, but it is.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_with_different_namespace_prefix_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XElement.Parse("<xml xmlns=\"urn:a\"/>");
+            var expected = XElement.Parse("<a:xml xmlns:a=\"urn:a\"/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XElement.Parse("<xml xmlns:a=\"urn:a\"/>");
+            var expected = XElement.Parse("<xml/>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_lacks_attributes_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XElement.Parse("<xml><element b=\"1\"/></xml>");
+            var expected = XElement.Parse("<xml><element a=\"b\" b=\"1\"/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected attribute \"a\" at \"/xml/element\" because we want to test the failure message, but found none.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_extra_attributes_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XElement.Parse("<xml><element a=\"b\"/></xml>");
+            var expected = XElement.Parse("<xml><element/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Didn't expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XElement.Parse("<xml><element a=\"b\"/></xml>");
+            var expected = XElement.Parse("<xml><element a=\"c\"/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected attribute \"a\" at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XElement.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
+            var expected = XElement.Parse("<xml><element a=\"b\"/></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Didn't expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_different_text_contents_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XElement.Parse("<xml>a</xml>");
+            var expected = XElement.Parse("<xml>b</xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("Expected content to be \"b\" at \"/xml\" because we want to test the failure message, but found \"a\".");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_with_different_comments_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var subject = XElement.Parse("<xml><!--Comment--><a/></xml>");
+            var expected = XElement.Parse("<xml><a/><!--Comment--></xml>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
         }
 
         #endregion


### PR DESCRIPTION
Also fixed a bug where the location for xml comparisons was incorrect after a selfclosed <xml /> element had been compared.

The tests for `XDocument/XElement.Should().BeEquivalent()` are not very covering. They basically just checks that semantical equivalency is used. The tests for `XmlNode` are much more extensive, as those are what I used to test the `XmlReaderValidator` implementation. How do you want the tests? I can think of three options.

1. Kept as it is
2. Also do full tests/specs for `XDocument/XElement` (will be a lot of copied tests)
3. Move the detailed tests to a separate class that tests `XmlReaderValidator` directly
