### PR TITLE
HaveInnerText, HaveElement and HaveAttribute for XmlElement

### DIFF
--- a/Src/FluentAssertions.Net40/Net40.csproj
+++ b/Src/FluentAssertions.Net40/Net40.csproj
@@ -81,7 +81,9 @@
     <Compile Include="ObjectAssertionsExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Xml\XmlAssertionExtensions.cs" />
+    <Compile Include="Xml\XmlElementAssertions.cs" />
     <Compile Include="Xml\XmlNodeAssertions.cs" />
+    <Compile Include="Xml\XmlNodeAssertionsofTSubjectTAssertions.cs" />
     <Compile Include="Xml\XmlNodeFormatter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/FluentAssertions.Net40/Xml/XmlAssertionExtensions.cs
+++ b/Src/FluentAssertions.Net40/Xml/XmlAssertionExtensions.cs
@@ -16,5 +16,10 @@ namespace FluentAssertions
         {
             return new XmlNodeAssertions(actualValue);
         }
+
+        public static XmlElementAssertions Should(this XmlElement actualValue)
+        {
+            return new XmlElementAssertions(actualValue);
+        }
     }
 }

--- a/Src/FluentAssertions.Net40/Xml/XmlElementAssertions.cs
+++ b/Src/FluentAssertions.Net40/Xml/XmlElementAssertions.cs
@@ -1,0 +1,226 @@
+﻿using FluentAssertions.Common;
+using FluentAssertions.Execution;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Xml;
+
+namespace FluentAssertions.Xml
+{
+    /// <summary>
+    /// Cointains a number of methods to assert that an <see cref="XmlElement"/>
+    /// is in the expected state./>
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class XmlElementAssertions : XmlNodeAssertions<XmlElement, XmlElementAssertions>
+    {
+        /// <summary>
+        /// Initialized a new instance of the <see cref="XmlElementAssertions"/>
+        /// class.
+        /// </summary>
+        /// <param name="xmlElement"></param>
+        public XmlElementAssertions(XmlElement xmlElement)
+            : base (xmlElement)
+        { }
+
+        /// <summary>
+        /// Asserts taht the current <see cref="XmlElement"/> has the specified
+        /// <paramref name="expected"/> inner text.
+        /// </summary>
+        /// <param name="expected">The expected value.</param>
+        public AndConstraint<XmlElementAssertions> HaveInnerText(string expected)
+        {
+            return HaveInnerText(expected, string.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlElement"/> has the specified
+        /// <paramref name="expected"/> inner text.
+        /// </summary>
+        /// <param name="expected">The expected value.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<XmlElementAssertions> HaveInnerText(string expected, string because, params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject.InnerText == expected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected XML element {0} to have value {1}{reason}, but found {2}.",
+                    Subject.Name, expected, Subject.InnerText);
+
+            return new AndConstraint<XmlElementAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlElement"/> has an attribute
+        /// with the specified <paramref name="expectedName"/>
+        /// and <paramref name="expectedValue"/>.
+        /// </summary>
+        /// <param name="expectedName">The name of the expected attribute</param>
+        /// <param name="expectedValue">The value of the expected attribute</param>
+
+        public AndConstraint<XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue)
+        {
+            return HaveAttribute(expectedName, expectedValue, string.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlElement"/> has an attribute
+        /// with the specified <paramref name="expectedName"/>
+        /// and <paramref name="expectedValue"/>.
+        /// </summary>
+        /// <param name="expectedName">The name of the expected attribute</param>
+        /// <param name="expectedValue">The value of the expected attribute</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs)
+        {
+            return HaveAttributeWithNamespace(expectedName, string.Empty, expectedValue, because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlElement"/> has an attribute
+        /// with the specified <paramref name="expectedName"/>, <param name="expectedNamespace"/>
+        /// and <paramref name="expectedValue"/>.
+        /// </summary>
+        /// <param name="expectedName">The name of the expected attribute</param>
+        /// <param name="expectedValue">The value of the expected attribute</param>
+        public AndConstraint<XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue)
+        {
+            return HaveAttributeWithNamespace(expectedName, expectedNamespace, expectedValue, string.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlElement"/> has an attribute
+        /// with the specified <paramref name="expectedName"/>, <param name="expectedNamespace"/>
+        /// and <paramref name="expectedValue"/>.
+        /// </summary>
+        /// <param name="expectedName">The name of the expected attribute</param>
+        /// <param name="expectedValue">The value of the expected attribute</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<XmlElementAssertions> HaveAttributeWithNamespace(
+            string expectedName,
+            string expectedNamespace,
+            string expectedValue,
+            string because, params object[] becauseArgs)
+        {
+            XmlAttribute attribute = Subject.Attributes[expectedName, expectedNamespace];
+
+            string expectedFormattedName =
+                (string.IsNullOrEmpty(expectedNamespace) ? "" : "{" + expectedNamespace + "}")
+                + expectedName;
+
+            Execute.Assertion
+                .ForCondition(attribute != null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected XML element to have attribute {0}" 
+                    + " with value {1}{reason}, but found no such attribute in {2}",
+                    expectedFormattedName, expectedValue, Subject);
+
+            Execute.Assertion
+                .ForCondition(attribute.Value == expectedValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected XML attribute {0} to have value {1}{reason}, but found {2}.",
+                    expectedFormattedName, expectedValue, attribute.Value);
+
+            return new AndConstraint<XmlElementAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlElement"/> has a direct child element with the specified
+        /// <paramref name="expectedName"/> name.
+        /// </summary>
+        /// <param name="expectedName">The name of the expected child element</param>
+        public AndWhichConstraint<XmlElementAssertions, XmlElement> HaveElement(string expectedName)
+        {
+            return HaveElement(expectedName, string.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlElement"/> has a direct child element with the specified
+        /// <paramref name="expectedName"/> name.
+        /// </summary>
+        /// <param name="expectedName">The name of the expected child element</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndWhichConstraint<XmlElementAssertions, XmlElement> HaveElement(
+            string expectedName,
+            string because,
+            params object[] becauseArgs)
+        {
+            return HaveElementWithNamespace(expectedName, string.Empty, because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlElement"/> has a direct child element with the specified
+        /// <paramref name="expectedName"/> name and <paramref name="expectedNamespace" /> namespace.
+        /// </summary>
+        /// <param name="expectedName">The name of the expected child element</param>
+        /// <param name="expectedNamespace">The namespace of the expected child element</param>
+        public AndWhichConstraint<XmlElementAssertions, XmlElement> HaveElementWithNamespace(
+            string expectedName, string expectedNamespace)
+        {
+            return HaveElementWithNamespace(expectedName, expectedNamespace, string.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlElement"/> has a direct child element with the specified
+        /// <paramref name="expectedName"/> name and <paramref name="expectedNamespace" /> namespace.
+        /// </summary>
+        /// <param name="expectedName">The name of the expected child element</param>
+        /// <param name="expectedNamespace">The namespace of the expected child element</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndWhichConstraint<XmlElementAssertions, XmlElement> HaveElementWithNamespace(
+            string expectedName,
+            string expectedNamespace,
+            string because,
+            params object[] becauseArgs)
+        {
+            XmlElement element = Subject[expectedName, expectedNamespace];
+
+            string expectedFormattedName =
+                (string.IsNullOrEmpty(expectedNamespace) ? "" : "{" + expectedNamespace + "}")
+                + expectedName;
+
+            Execute.Assertion
+                .ForCondition(element != null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected XML element {0} to have child element \"" + 
+                    expectedFormattedName.ToString().Escape(escapePlaceholders: true) + "\"{reason}" +
+                        ", but no such child element was found.", Subject);
+
+            return new AndWhichConstraint<XmlElementAssertions, XmlElement>(this, element);
+        }
+    }
+}

--- a/Src/FluentAssertions.Net40/Xml/XmlNodeAssertions.cs
+++ b/Src/FluentAssertions.Net40/Xml/XmlNodeAssertions.cs
@@ -1,8 +1,7 @@
-﻿using FluentAssertions.Execution;
-using FluentAssertions.Primitives;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Xml;
 
@@ -12,84 +11,10 @@ namespace FluentAssertions.Xml
     /// Contains a number of methods to assert that an <see cref="XmlNode"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class XmlNodeAssertions : ReferenceTypeAssertions<XmlNode, XmlNodeAssertions>
+    public class XmlNodeAssertions : XmlNodeAssertions<XmlNode, XmlNodeAssertions>
     {
         public XmlNodeAssertions(XmlNode xmlNode)
-        {
-            Subject = xmlNode;
-        }
-
-        /// <summary>
-        /// Asserts that the current <see cref="XmlNode"/> is equivalent to the <paramref name="expected"/> element.
-        /// </summary>
-        /// <param name="expected">The expected element</param>
-        public AndConstraint<XmlNodeAssertions> BeEquivalentTo(XmlNode expected)
-        {
-            return BeEquivalentTo(expected, string.Empty);
-        }
-
-        /// <summary>
-        /// Asserts that the current <see cref="XmlNode"/> is equivalent to the <paramref name="expected"/> node.
-        /// </summary>
-        /// <param name="expected">The expected node</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
-        public AndConstraint<XmlNodeAssertions> BeEquivalentTo(XmlNode expected, string because, params object[] reasonArgs)
-        {
-            using (XmlNodeReader subjectReader = new XmlNodeReader(Subject))
-            using (XmlNodeReader expectedReader = new XmlNodeReader(expected))
-            {
-                new XmlReaderValidator(subjectReader, expectedReader, because, reasonArgs).Validate(true);
-            }
-
-            return new AndConstraint<XmlNodeAssertions>(this);
-        }
-
-        /// <summary>
-        /// Asserts that the current <see cref="XmlNode"/> is not equivalent to
-        /// the <paramref name="unexpected"/> node.
-        /// </summary>
-        /// <param name="unexpected">The unexpected node</param>
-        public AndConstraint<XmlNodeAssertions> NotBeEquivalentTo(XmlNode unexpected)
-        {
-            return NotBeEquivalentTo(unexpected, string.Empty);
-        }
-
-        /// <summary>
-        /// Asserts that the current <see cref="XmlNode"/> is not equivalent to
-        /// the <paramref name="unexpected"/> node.
-        /// </summary>
-        /// <param name="unexpected">The unexpected node</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="reasonArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
-        /// <returns></returns>
-        public AndConstraint<XmlNodeAssertions> NotBeEquivalentTo(XmlNode unexpected, string because, params object[] reasonArgs)
-        {
-            using (XmlNodeReader subjectReader = new XmlNodeReader(Subject))
-            using (XmlNodeReader unexpectedReader = new XmlNodeReader(unexpected))
-            {
-                new XmlReaderValidator(subjectReader, unexpectedReader, because, reasonArgs).Validate(false);
-            }
-
-            return new AndConstraint<XmlNodeAssertions>(this);
-        }
-
-        /// <summary>
-        /// Returns the type of the subject the assertion applies on.
-        /// </summary>
-        protected override string Context
-        {
-            get { return "Xml Node"; }
-        }
+            : base(xmlNode)
+        { }
     }
 }

--- a/Src/FluentAssertions.Net40/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
+++ b/Src/FluentAssertions.Net40/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
@@ -1,0 +1,97 @@
+﻿using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Xml;
+
+namespace FluentAssertions.Xml
+{
+    /// <summary>
+    /// Contains a number of methods to assert that an <see cref="XmlNode"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class XmlNodeAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<TSubject, TAssertions>
+        where TAssertions: XmlNodeAssertions<TSubject, TAssertions>
+        where TSubject : XmlNode
+    {
+        public XmlNodeAssertions(TSubject xmlNode)
+        {
+            Subject = xmlNode;
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlNode"/> is equivalent to the <paramref name="expected"/> element.
+        /// </summary>
+        /// <param name="expected">The expected element</param>
+        public AndConstraint<TAssertions> BeEquivalentTo(XmlNode expected)
+        {
+            return BeEquivalentTo(expected, string.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlNode"/> is equivalent to the <paramref name="expected"/> node.
+        /// </summary>
+        /// <param name="expected">The expected node</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="reasonArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeEquivalentTo(XmlNode expected, string because, params object[] reasonArgs)
+        {
+            using (XmlNodeReader subjectReader = new XmlNodeReader(Subject))
+            using (XmlNodeReader expectedReader = new XmlNodeReader(expected))
+            {
+                new XmlReaderValidator(subjectReader, expectedReader, because, reasonArgs).Validate(true);
+            }
+
+            return new AndConstraint<TAssertions>((TAssertions)(this));
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlNode"/> is not equivalent to
+        /// the <paramref name="unexpected"/> node.
+        /// </summary>
+        /// <param name="unexpected">The unexpected node</param>
+        public AndConstraint<TAssertions> NotBeEquivalentTo(XmlNode unexpected)
+        {
+            return NotBeEquivalentTo(unexpected, string.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="XmlNode"/> is not equivalent to
+        /// the <paramref name="unexpected"/> node.
+        /// </summary>
+        /// <param name="unexpected">The unexpected node</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="reasonArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        /// <returns></returns>
+        public AndConstraint<TAssertions> NotBeEquivalentTo(XmlNode unexpected, string because, params object[] reasonArgs)
+        {
+            using (XmlNodeReader subjectReader = new XmlNodeReader(Subject))
+            using (XmlNodeReader unexpectedReader = new XmlNodeReader(unexpected))
+            {
+                new XmlReaderValidator(subjectReader, unexpectedReader, because, reasonArgs).Validate(false);
+            }
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Returns the type of the subject the assertion applies on.
+        /// </summary>
+        protected override string Context
+        {
+            get { return "Xml Node"; }
+        }
+    }
+}

--- a/Src/FluentAssertions.Net45/Net45.csproj
+++ b/Src/FluentAssertions.Net45/Net45.csproj
@@ -104,8 +104,14 @@
     <Compile Include="..\FluentAssertions.Net40\Xml\XmlAssertionExtensions.cs">
       <Link>Xml\XmlAssertionExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\FluentAssertions.Net40\Xml\XmlElementAssertions.cs">
+      <Link>Xml\XmlElementAssertions.cs</Link>
+    </Compile>
     <Compile Include="..\FluentAssertions.Net40\Xml\XmlNodeAssertions.cs">
       <Link>Xml\XmlNodeAssertions.cs</Link>
+    </Compile>
+    <Compile Include="..\FluentAssertions.Net40\Xml\XmlNodeAssertionsofTSubjectTAssertions.cs">
+      <Link>Xml\XmlNodeAssertionsofTSubjectTAssertions.cs</Link>
     </Compile>
     <Compile Include="..\FluentAssertions.Net40\Xml\XmlNodeFormatter.cs">
       <Link>Xml\XmlNodeFormatter.cs</Link>

--- a/Tests/FluentAssertions.Net40.Specs/Net40.Specs.csproj
+++ b/Tests/FluentAssertions.Net40.Specs/Net40.Specs.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Chill\AutofacChillContainer.cs" />
     <Compile Include="Chill\DefaultChillContainer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="XmlElementAssertionSpecs.cs" />
     <Compile Include="XmlNodeAssertionSpecs.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/FluentAssertions.Net40.Specs/XmlElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Net40.Specs/XmlElementAssertionSpecs.cs
@@ -1,0 +1,547 @@
+﻿using FluentAssertions.Formatting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml;
+
+namespace FluentAssertions.Specs
+{
+    [TestClass]
+    public class XmlElementAssertionSpecs
+    {
+        #region BeEquivalent
+
+        [TestMethod]
+        public void When_asserting_xml_element_is_equivalent_to_another_xml_element_with_same_contents_it_should_succeed()
+        {
+            // This test is basically just a check that the BeEquivalent method
+            // is available on XmlElementAssertions, which it should be if
+            // XmlElementAssertions inherits XmlNodeAssertions.
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user>grega</user>");
+            var element = xmlDoc.DocumentElement;
+            var expectedDoc = new XmlDocument();
+            expectedDoc.LoadXml(@"<user>grega</user>");
+            var expected = expectedDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().BeEquivalentTo(expected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+
+        }
+        #endregion
+
+        #region HaveValue
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_a_specific_inner_text_and_it_does_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user>grega</user>");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveInnerText("grega");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_a_specific_inner_text_but_it_has_a_different_inner_text_it_should_throw()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user>grega</user>");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveInnerText("stamac");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_a_specific_inner_text_but_it_has_a_different_inner_text_it_should_throw_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user>grega</user>");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveInnerText("stamac", "because we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected XML element \"user\" to have value \"stamac\"" +
+                    " because we want to test the failure message" +
+                        ", but found \"grega\".");
+        }
+
+        #endregion
+
+        #region HaveAttribute
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_attribute_with_specific_value_and_it_does_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user name=""martin"" />");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveAttribute("name", "martin");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_and_it_does_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "martin");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user name=""martin"" />");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveAttribute("age", "36");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveAttributeWithNamespace("age", "http://www.example.com/2012/test", "36");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user name=""martin"" />");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveAttribute("age", "36", "because we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected XML element to have attribute \"age\" with value \"36\"" +
+                    " because we want to test the failure message" +
+                        ", but found no such attribute in <user name=\\\"martin\\\"*");
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveAttributeWithNamespace("age", "http://www.example.com/2012/test", "36", "because we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected XML element to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\"" +
+                    " because we want to test the failure message" +
+                        ", but found no such attribute in <user xmlns:a=\\\"http:...");
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user name=""martin"" />");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveAttribute("name", "dennis");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "dennis");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user name=""martin"" />");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveAttribute("name", "dennis", "because we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected XML attribute \"name\" to have value \"dennis\"" +
+                    " because we want to test the failure message" +
+                        ", but found \"martin\".");
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "dennis", "because we want to test the failure {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected XML attribute \"{http://www.example.com/2012/test}name\" to have value \"dennis\"" +
+                    " because we want to test the failure message" +
+                        ", but found \"martin\".");
+        }
+
+        #endregion
+
+        #region HaveElement
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_child_element_and_it_does_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xml = new XmlDocument();
+            xml.LoadXml(
+                @"<parent>
+                    <child />
+                  </parent>");
+            var element = xml.DocumentElement;
+
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveElement("child");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_child_element_with_ns_and_it_does_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(
+                @"<parent xmlns:c='http://www.example.com/2012/test'>
+                    <c:child />
+                  </parent>");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveElementWithNamespace("child", "http://www.example.com/2012/test");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_child_element_but_it_does_not_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(
+                @"<parent>
+                    <child />
+                  </parent>");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveElement("unknown");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_child_element_with_ns_but_it_does_not_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(
+                @"<parent>
+                    <child />
+                  </parent>");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveElementWithNamespace("unknown", "http://www.example.com/2012/test");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_child_element_but_it_does_not_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(
+                @"<parent>
+                    <child />
+                  </parent>");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveElement("unknown", "because we want to test the failure message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            string expectedMessage = string.Format("Expected XML element {0} to have child element \"unknown\"" +
+                " because we want to test the failure message" +
+                    ", but no such child element was found.", Formatter.ToString(element));
+
+            act.ShouldThrow<AssertFailedException>().WithMessage(expectedMessage);
+        }
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(
+                @"<parent>
+                    <child />
+                  </parent>");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                element.Should().HaveElementWithNamespace("unknown", "http://www.example.com/2012/test", "because we want to test the failure message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            string expectedMessage = string.Format("Expected XML element {0} to have child element \"{{http://www.example.com/2012/test}}unknown\"" +
+                " because we want to test the failure message" +
+                    ", but no such child element was found.", Formatter.ToString(element));
+
+            act.ShouldThrow<AssertFailedException>().WithMessage(expectedMessage);
+        }
+
+
+        [TestMethod]
+        public void When_asserting_xml_element_has_child_element_it_should_return_the_matched_element_in_the_which_property()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(
+                @"<parent>
+                    <child attr='1' />
+                  </parent>");
+            var element = xmlDoc.DocumentElement;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            var matchedElement = element.Should().HaveElement("child").Subject;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            matchedElement.Should().BeOfType<XmlElement>()
+                .And.HaveAttribute("attr", "1");
+            matchedElement.Name.Should().Be("child");
+        }
+
+        #endregion
+    }
+}

--- a/Tests/FluentAssertions.Net45.Specs/Net45.Specs.csproj
+++ b/Tests/FluentAssertions.Net45.Specs/Net45.Specs.csproj
@@ -84,6 +84,9 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="..\FluentAssertions.Net40.Specs\XmlElementAssertionSpecs.cs">
+      <Link>XmlElementAssertionSpecs.cs</Link>
+    </Compile>
     <Compile Include="..\FluentAssertions.Net40.Specs\XmlNodeAssertionSpecs.cs">
       <Link>XmlNodeAssertionSpecs.cs</Link>
     </Compile>


### PR DESCRIPTION
- Follows the principles of the corresponding methods on XDocument/XElement.
- It doesn't make sense to add these on XmlDocument as the DocumentElement
  is an explicit property there (XDocument behaves implicitly as the document
  XElement).
- Named the test HaveInnerText because the Value property is always null on XmlElements.