### PR TITLE
Fix: NullReferenceException occurs from AsyncFunctionAssertions.Shoul…

### DIFF
--- a/Src/Core/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/Core/Specialized/AsyncFunctionAssertions.cs
@@ -72,14 +72,14 @@ namespace FluentAssertions.Specialized
                 Task task = Subject();
                 task.Wait();
             }
-            catch (Exception aggregateException)
+            catch (Exception exception)
             {
-                Exception exception = aggregateException.InnerException;
+                Exception cause = exception.InnerException ?? exception;
 
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect any exception{reason}, but found a {0} with message {1}.",
-                        exception.GetType(), exception.Message);
+                        cause.GetType(), cause.Message);
             }
         }
 

--- a/Tests/FluentAssertions.Net45.Specs/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Net45.Specs/AsyncFunctionExceptionAssertionSpecs.cs
@@ -221,6 +221,29 @@ namespace FluentAssertions.Net45.Specs
             action.ShouldThrow<AssertFailedException>()
                 .WithMessage("Did not expect System.ArgumentException, but found one*");
         }
+
+        [TestMethod]
+        public void When_async_method_throws_exception_without_inner_exception_it_should_throw_AssertFailedException()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Func<Task> asyncAction = () =>
+            {
+                throw new InvalidOperationException();
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => asyncAction.ShouldNotThrow();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<AssertFailedException>()
+                .WithMessage("Did not expect any exception, but found*");
+        }
     }
 
     internal class AsyncClass


### PR DESCRIPTION
…dNotThrow() when exception doen not have inner exception

Rebased version of #408 