### PR TITLE
Not contains fix

### DIFF
--- a/Src/Core/Collections/CollectionAssertions.cs
+++ b/Src/Core/Collections/CollectionAssertions.cs
@@ -900,6 +900,7 @@ namespace FluentAssertions.Collections
 
         /// <summary>
         /// Asserts that the current collection does not contain the supplied <paramref name="unexpected" /> item.
+        /// Elements are compared using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
         /// <param name="unexpected">The element that is not expected to be in the collection</param>
         /// <param name="because">
@@ -927,6 +928,23 @@ namespace FluentAssertions.Collections
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current collection does not contain the supplied items. Elements are compared
+        /// using their <see cref="object.Equals(object)" /> implementation.
+        /// </summary>
+        /// <param name="unexpected">An <see cref="IEnumerable"/> with the unexpected elements.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotContain(IEnumerable expected, string because = "", params object[] becauseArgs)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/Src/Core/Collections/CollectionAssertions.cs
+++ b/Src/Core/Collections/CollectionAssertions.cs
@@ -917,8 +917,8 @@ namespace FluentAssertions.Collections
                 throw new NullReferenceException("Cannot verify non-containment against a <null> collection");
             }
 
-            IEnumerable<object> expectedObjects = unexpected.Cast<object>().ToArray();
-            if (!expectedObjects.Any())
+            IEnumerable<object> unexpectedObjects = unexpected.Cast<object>().ToArray();
+            if (!unexpectedObjects.Any())
             {
                 throw new ArgumentException("Cannot verify non-containment against an empty collection");
             }
@@ -941,22 +941,22 @@ namespace FluentAssertions.Collections
             }
             else
             {
-                IEnumerable<object> foundItems = expectedObjects.Intersect(Subject.Cast<object>());
+                IEnumerable<object> foundItems = unexpectedObjects.Intersect(Subject.Cast<object>());
                 if (foundItems.Any())
                 {
-                    if (expectedObjects.Count() > 1)
+                    if (unexpectedObjects.Count() > 1)
                     {
                         Execute.Assertion
                             .BecauseOf(because, becauseArgs)
-                            .FailWith("Expected {context:collection} {0} to not contain {1}{reason}, but could not find {2}.", Subject,
+                            .FailWith("Expected {context:collection} {0} to not contain {1}{reason}, but found {2}.", Subject,
                                 unexpected, foundItems);
                     }
                     else
                     {
                         Execute.Assertion
                             .BecauseOf(because, becauseArgs)
-                            .FailWith("Expected {context:collection} {0} to not contain {1}{reason}.", Subject,
-                                unexpected.Cast<object>().First());
+                            .FailWith("Expected {context:collection} {0} to not contain element {1}{reason}.", Subject,
+                                unexpectedObjects.First());
                     }
                 }
             }

--- a/Src/Core/Collections/GenericDictionaryAssertions.cs
+++ b/Src/Core/Collections/GenericDictionaryAssertions.cs
@@ -460,7 +460,7 @@ namespace FluentAssertions.Collections
 
             if (!expectedValues.Any())
             {
-                throw new ArgumentException("Cannot verify value containment against an empty dictionary");
+                throw new ArgumentException("Cannot verify value containment with an empty sequence");
             }
 
             if (ReferenceEquals(Subject, null))
@@ -473,7 +473,7 @@ namespace FluentAssertions.Collections
             var missingValues = expectedValues.Except(Subject.Values);
             if (missingValues.Any())
             {
-                if (expectedValues.Count() > 1)
+                if (expectedValues.Length > 1)
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
@@ -538,6 +538,72 @@ namespace FluentAssertions.Collections
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith("{context:Dictionary} {0} should not contain value {1}{reason}, but found it anyhow.", Subject, unexpected);
+            }
+
+            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the dictionary does not contain any of the specified values. Values are compared using
+        /// their <see cref="object.Equals(object)" /> implementation.
+        /// </summary>
+        /// <param name="unexpected">The unexpected values</param>
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected)
+        {
+            return NotContainValues(unexpected, String.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the dictionary does not contain any of the specified values. Values are compared using
+        /// their <see cref="object.Equals(object)" /> implementation.
+        /// </summary>
+        /// <param name="unexpected">The unexpected values</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainValues(IEnumerable<TValue> unexpected,
+            string because = "", params object[] becauseArgs)
+        {
+            if (unexpected == null)
+            {
+                throw new NullReferenceException("Cannot verify value containment against a <null> collection of values");
+            }
+
+            var unexpectedValues = unexpected.ToArray();
+
+            if (!unexpectedValues.Any())
+            {
+                throw new ArgumentException("Cannot verify value containment with an empty sequence");
+            }
+
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} to not contain value {0}{reason}, but found {1}.", unexpected, Subject);
+            }
+
+            var foundValues = unexpectedValues.Intersect(Subject.Values);
+            if (foundValues.Any())
+            {
+                if (unexpectedValues.Length > 1)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to not contain value {1}{reason}, but found {2}.", Subject,
+                            unexpected, foundValues);
+                }
+                else
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to not contain value {1}{reason}.", Subject,
+                            unexpected.Cast<object>().First());
+                }
             }
 
             return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);

--- a/Src/Core/Collections/GenericDictionaryAssertions.cs
+++ b/Src/Core/Collections/GenericDictionaryAssertions.cs
@@ -323,7 +323,7 @@ namespace FluentAssertions.Collections
 
             if (!expectedKeys.Any())
             {
-                throw new ArgumentException("Cannot verify key containment against an empty dictionary");
+                throw new ArgumentException("Cannot verify key containment against an empty sequence");
             }
 
             if (ReferenceEquals(Subject, null))
@@ -387,6 +387,73 @@ namespace FluentAssertions.Collections
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith("{context:Dictionary} {0} should not contain key {1}{reason}, but found it anyhow.", Subject, unexpected);
+            }
+
+            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the dictionary does not contain any of the specified keys. Keys are compared using
+        /// their <see cref="object.Equals(object)" /> implementation.
+        /// </summary>
+        /// <param name="unexpected">The unexpected keys</param>
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected)
+        {
+            return NotContainKeys(unexpected, String.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the dictionary does not contain any of the specified keys. Keys are compared using
+        /// their <see cref="object.Equals(object)" /> implementation.
+        /// </summary>
+        /// <param name="unexpected">The unexpected keys</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(IEnumerable<TKey> unexpected,
+            string because = "", params object[] becauseArgs)
+        {
+            if (unexpected == null)
+            {
+                throw new NullReferenceException("Cannot verify key containment against a <null> collection of keys");
+            }
+
+            TKey[] unexpectedKeys = unexpected.ToArray();
+
+            if (!unexpectedKeys.Any())
+            {
+                throw new ArgumentException("Cannot verify key containment against an empty sequence");
+            }
+
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} to contain keys {0}{reason}, but found {1}.", unexpected, Subject);
+            }
+
+            var foundKeys = unexpectedKeys.Intersect(Subject.Keys);
+
+            if (foundKeys.Any())
+            {
+                if (unexpectedKeys.Count() > 1)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to not contain key {1}{reason}, but found {2}.", Subject,
+                            unexpected, foundKeys);
+                }
+                else
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:dictionary} {0} to not contain key {1}{reason}.", Subject,
+                            unexpected.Cast<object>().First());
+                }
             }
 
             return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);

--- a/Src/Core/Collections/NonGenericCollectionAssertions.cs
+++ b/Src/Core/Collections/NonGenericCollectionAssertions.cs
@@ -127,5 +127,28 @@ namespace FluentAssertions.Collections
 
             return base.Contain(new [] { expected }, because, becauseArgs);
         }
+
+        /// <summary>
+        /// Asserts that the current collection does not contain the supplied <paramref name="unexpected" /> item.
+        /// Elements are compared using their <see cref="object.Equals(object)" /> implementation.
+        /// </summary>
+        /// <param name="unexpected">The element that is not expected to be in the collection</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<NonGenericCollectionAssertions> NotContain(object unexpected, string because = "",
+            params object[] becauseArgs)
+        {
+            if (unexpected is IEnumerable)
+            {
+                return base.NotContain((IEnumerable)unexpected, because, becauseArgs);
+            }
+
+            return base.NotContain(new[] { unexpected }, because, becauseArgs);
+        }
     }
 }

--- a/Src/Core/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/Core/Collections/SelfReferencingCollectionAssertions.cs
@@ -400,7 +400,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("{context:Collection} {0} should not have any items matching {1}{reason}.", Subject, predicate.Body);
+                    .FailWith("Expected {context:Collection} {0} to not have any items matching {1}{reason}.", Subject, predicate.Body);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/Core/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/Core/Collections/SelfReferencingCollectionAssertions.cs
@@ -242,8 +242,8 @@ namespace FluentAssertions.Collections
         /// </summary>
         /// <param name="expected">The expectation item.</param>
         /// <param name="because">
-        /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
-        /// start with the word <i>because</i>, it is prepended to the message.
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
@@ -288,8 +288,8 @@ namespace FluentAssertions.Collections
         /// </summary>
         /// <param name="predicate">A predicate to match the items in the collection against.</param>
         /// <param name="because">
-        /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
-        /// start with the word <i>because</i>, it is prepended to the message.
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
@@ -318,8 +318,8 @@ namespace FluentAssertions.Collections
         /// </summary>
         /// <param name="predicate">A predicate to match the items in the collection against.</param>
         /// <param name="because">
-        /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
-        /// start with the word <i>because</i>, it is prepended to the message.
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
@@ -347,6 +347,17 @@ namespace FluentAssertions.Collections
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
+        /// <summary>
+        /// Asserts that the current collection does not contain the supplied <paramref name="unexpected" /> item.
+        /// </summary>
+        /// <param name="unexpected">The element that is not expected to be in the collection</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
+        /// </param>
         public AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs)
         {
             if (ReferenceEquals(Subject, null))
@@ -368,14 +379,18 @@ namespace FluentAssertions.Collections
                     item => !EqualityComparer<T>.Default.Equals(item, unexpected)));
         }
 
+        /// <summary>
+        /// Asserts that the collection does not contain some extra items in addition to the original items.
+        /// </summary>
+        /// <param name="unexpectedItemsList">An <see cref="IEnumerable{T}"/> of unexpected items.</param>
+        /// <param name="additionalUnexpectedItems">Additional items that are not expected to be contained by the collection.</param>
         public AndConstraint<TAssertions> NotContain(IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems)
         {
             var list = new List<T>(unexpectedItemsList);
             list.AddRange(additionalUnexpectedItems);
             return NotContain((IEnumerable)list);
         }
-
-
+        
         /// <summary>
         /// Asserts that the collection does not contain any items that match the predicate.
         /// </summary>

--- a/Src/Core/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/Core/Collections/SelfReferencingCollectionAssertions.cs
@@ -347,6 +347,35 @@ namespace FluentAssertions.Collections
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
+        public AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs)
+        {
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:collection} to not contain {0}{reason}, but found <null>.", unexpected);
+            }
+
+            if (Subject.Contains(unexpected))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:collection} {0} to not contain {1}{reason}.", Subject, unexpected);
+            }
+
+            return new AndWhichConstraint<TAssertions, T>((TAssertions)this,
+                Subject.Where(
+                    item => !EqualityComparer<T>.Default.Equals(item, unexpected)));
+        }
+
+        public AndConstraint<TAssertions> NotContain(IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems)
+        {
+            var list = new List<T>(unexpectedItemsList);
+            list.AddRange(additionalUnexpectedItems);
+            return NotContain((IEnumerable)list);
+        }
+
+
         /// <summary>
         /// Asserts that the collection does not contain any items that match the predicate.
         /// </summary>

--- a/Src/Core/Collections/StringCollectionAssertions.cs
+++ b/Src/Core/Collections/StringCollectionAssertions.cs
@@ -117,5 +117,26 @@ namespace FluentAssertions.Collections
             args.AddRange(becauseArgs);
             return base.Contain(expected, because, args.ToArray());
         }
+
+        /// <summary>
+        /// Asserts that the current collection does not contain the supplied items. Elements are compared
+        /// using their <see cref="object.Equals(object)" /> implementation.
+        /// </summary>
+        /// <param name="unexpected">An <see cref="IEnumerable"/> with the unexpected elements.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<StringCollectionAssertions> NotContain(IEnumerable<string> unexpected, string because = null,
+            object becauseArg = null,
+            params object[] becauseArgs)
+        {
+            var args = new List<object> { becauseArg };
+            args.AddRange(becauseArgs);
+            return base.NotContain(unexpected, because, args.ToArray());
+        }
     }
 }

--- a/Tests/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
@@ -1529,6 +1529,27 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void When_asserting_collection_does_contain_item_against_null_collection_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should()
+                .Contain(1, "because we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected collection to contain {1} because we want to test the behaviour with a null subject, but found <null>.");
+        }
+
+        [TestMethod]
         public void When_a_collection_does_not_contain_another_collection_it_should_throw_with_clear_explanation()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -1597,13 +1618,13 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => collection.Should().NotContain(1, "because we {0} like it", "don't");
+            Action act = () => collection.Should().NotContain(1, "because we {0} like it, but found it anyhow", "don't");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
-                "Collection {1, 2, 3} should not contain 1 because we don't like it, but found it anyhow.");
+                "Expected collection {1, 2, 3} to not contain element 1 because we don't like it, but found it anyhow.");
         }
 
         [TestMethod]
@@ -1623,7 +1644,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
-                "Collection {1, 2, 3} should not have any items matching (item == 2) because 2s are evil.");
+                "Expected collection {1, 2, 3} to not have any items matching (item == 2) because 2s are evil.");
         }
 
         [TestMethod]
@@ -1658,7 +1679,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
-                "Expected collection not to contain element 1 because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to not contain {1} because we want to test the behaviour with a null subject, but found <null>.");
         }
         
         [TestMethod]
@@ -1679,7 +1700,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
-                "Expected collection {1, 2, 3} should not contain {1, 2, 4} because we don't like them, but found {1, 2}.");
+                "Expected collection {1, 2, 3} to not contain {1, 2, 4} because we don't like them, but found {1, 2}.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
@@ -1580,6 +1580,13 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void Should_succeed_when_asserting_collection_does_not_contain_any_items_that_is_not_in_the_collection()
+        {
+            IEnumerable<int> collection = new[] { 1, 2, 3 };
+            collection.Should().NotContain(new[] { 4, 5 });
+        }
+        
+        [TestMethod]
         public void When_collection_contains_an_unexpected_item_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -1652,6 +1659,27 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
                 "Expected collection not to contain element 1 because we want to test the behaviour with a null subject, but found <null>.");
+        }
+        
+        [TestMethod]
+        public void When_collection_contains_unexpected_items_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { 1, 2, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should()
+                .NotContain(new[] { 1, 2, 4 }, "because we {0} like them", "don't");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected collection {1, 2, 3} should not contain {1, 2, 4} because we don't like them, but found {1, 2}.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -1124,10 +1124,22 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void Should_succeed_when_asserting_collection_contains_multiple_items_from_the_collection_in_any_order()
+        public void When_asserting_collection_contains_multiple_items_from_the_collection_in_any_order_it_should_succeed()
         {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
             IEnumerable<string> collection = new [] { "one", "two", "three" };
-            collection.Should().Contain(new [] { "two", "one" });
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().Contain(new [] { "two", "one" });
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow<AssertFailedException>();
         }
 
         [TestMethod]
@@ -1195,10 +1207,22 @@ namespace FluentAssertions.Specs
         #region Not Contain
 
         [TestMethod]
-        public void Should_succeed_when_asserting_collection_does_not_contain_an_item_that_is_not_in_the_collection()
+        public void When_collection_does_not_contain_an_item_that_is_not_in_the_collection_it_should_not_throw()
         {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
             IEnumerable<string> collection = new [] { "one", "two", "three" };
-            collection.Should().NotContain("four");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotContain("four");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow<AssertFailedException>();
         }
 
         [TestMethod]

--- a/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -1212,13 +1212,13 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => collection.Should().NotContain("one", "because we {0} like it, but found it anyhow.", "don't");
+            Action act = () => collection.Should().NotContain("one", "because we {0} like it, but found it anyhow", "don't");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
-                "Expected collection {\"one\", \"two\", \"three\"} should not contain \"one\" because we don't like it, but found it anyhow.");
+                "Expected collection {\"one\", \"two\", \"three\"} to not contain \"one\" because we don't like it, but found it anyhow.");
         }
 
         [TestMethod]
@@ -1238,7 +1238,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
-                "Collection {\"one\", \"two\", \"three\"} should not have any items matching (item == \"two\") because twos are evil.");
+                "Expected collection {\"one\", \"two\", \"three\"} to not have any items matching (item == \"two\") because twos are evil.");
         }
 
         [TestMethod]
@@ -1273,7 +1273,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
-                "Expected collection to not contain element \"one\" because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to not contain \"one\" because we want to test the behaviour with a null subject, but found <null>.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -1198,7 +1198,7 @@ namespace FluentAssertions.Specs
         public void Should_succeed_when_asserting_collection_does_not_contain_an_item_that_is_not_in_the_collection()
         {
             IEnumerable<string> collection = new [] { "one", "two", "three" };
-            collection.Should().NotContain(4);
+            collection.Should().NotContain("four");
         }
 
         [TestMethod]
@@ -1212,13 +1212,13 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => collection.Should().NotContain("one", "because we {0} like it", "don't");
+            Action act = () => collection.Should().NotContain("one", "because we {0} like it, but found it anyhow.", "don't");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
-                "Collection {\"one\", \"two\", \"three\"} should not contain \"one\" because we don't like it, but found it anyhow.");
+                "Expected collection {\"one\", \"two\", \"three\"} should not contain \"one\" because we don't like it, but found it anyhow.");
         }
 
         [TestMethod]
@@ -1267,13 +1267,13 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should()
-                .NotContain(1, "because we want to test the behaviour with a null subject");
+                .NotContain("one", "because we want to test the behaviour with a null subject");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
-                "Expected collection not to contain element 1 because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to not contain element \"one\" because we want to test the behaviour with a null subject, but found <null>.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionsSpecs.cs
@@ -226,6 +226,26 @@ namespace FluentAssertions.Specs
                 "Expected collection not to contain (x == \"xxx\") because we're checking how it reacts to a null subject, but found <null>.");
         }
 
+        [TestMethod]
+        public void When_a_collection_does_contain_the_combination_of_a_collection_and_a_single_item_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<object> strings = new[] { "string1", "string2" };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => strings.Should().NotContain(new[] { "string3", "string4" }, new object[] { "string2" });
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected collection {\"string1\", \"string2\"} to not contain {\"string3\", \"string4\", \"string2\"}, but found {\"string2\"}.");
+        }
+
         #endregion
 
         #region Only Contain (Predicate)

--- a/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -906,25 +906,49 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void Should_succeed_when_asserting_dictionary_does_not_contain_a_key_that_is_not_in_the_dictionary()
+        public void When_dictionary_does_not_contain_a_key_that_is_not_in_the_dictionary_it_should_not_throw()
         {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
             var dictionary = new Dictionary<int, string>
             {
                 { 1, "One" },
                 { 2, "Two" }
             };
-            dictionary.Should().NotContainKey(4);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().NotContainKey(4);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow<AssertFailedException>();
         }
 
         [TestMethod]
-        public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_keys_from_the_dictionary()
+        public void When_dictionary_does_not_contain_multiple_keys_from_the_dictionary_it_should_not_throw()
         {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
             var dictionary = new Dictionary<int, string>
             {
                 { 1, "One" },
                 { 2, "Two" }
             };
-            dictionary.Should().NotContainKeys(3, 4);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().NotContainKeys(3, 4);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow<AssertFailedException>();
         }
 
         [TestMethod]
@@ -1127,14 +1151,26 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void Should_succeed_when_asserting_dictionary_contains_multiple_values_from_the_dictionary()
+        public void When_dictionary_contains_multiple_values_from_the_dictionary_it_should_not_throw()
         {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
             var dictionary = new Dictionary<int, string>
             {
                 { 1, "One" },
                 { 2, "Two" }
             };
-            dictionary.Should().ContainValues("Two", "One");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().ContainValues("Two", "One");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow<AssertFailedException>();
         }
 
         [TestMethod]
@@ -1210,14 +1246,26 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void Should_succeed_when_asserting_dictionary_does_not_contain_a_value_that_is_not_in_the_dictionary()
+        public void When_dictionary_does_not_contain_a_value_that_is_not_in_the_dictionary_it_should_not_throw()
         {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
             var dictionary = new Dictionary<int, string>
             {
                 { 1, "One" },
                 { 2, "Two" }
             };
-            dictionary.Should().NotContainValue("Three");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().NotContainValue("Three");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow<AssertFailedException>();
         }
 
         [TestMethod]
@@ -1266,16 +1314,28 @@ namespace FluentAssertions.Specs
         }
         
         [TestMethod]
-        public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_values_from_the_dictionary()
+        public void When_dictionary_does_not_contain_multiple_values_from_the_dictionary_should_not_throw()
         {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
             var dictionary = new Dictionary<int, string>
             {
                 { 1, "One" },
                 { 2, "Two" }
             };
-            dictionary.Should().NotContainValues("Three", "Four");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().NotContainValues("Three", "Four");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow<AssertFailedException>();
         }
-        
+
         [TestMethod]
         public void When_a_dictionary_contains_a_number_of_values_it_should_throw_with_clear_explanation()
         {

--- a/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -902,7 +902,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<ArgumentException>().WithMessage(
-                "Cannot verify key containment against an empty dictionary");
+                "Cannot verify key containment against an empty sequence");
         }
 
         [TestMethod]
@@ -914,6 +914,17 @@ namespace FluentAssertions.Specs
                 { 2, "Two" }
             };
             dictionary.Should().NotContainKey(4);
+        }
+
+        [TestMethod]
+        public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_keys_from_the_dictionary()
+        {
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+            dictionary.Should().NotContainKeys(3, 4);
         }
 
         [TestMethod]
@@ -959,6 +970,54 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
                 "Expected dictionary not to contain key 1 because we want to test the behaviour with a null subject, but found <null>.");
+        }
+
+        [TestMethod]
+        public void When_a_dictionary_contains_a_list_of_keys_it_should_throw_with_clear_explanation()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().NotContainKeys(new[] { 2, 3 }, "because {0}", "we do");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary {[1, One], [2, Two]} to not contain key {2, 3} because we do, but found {2}.");
+        }
+
+        [TestMethod]
+        public void When_the_noncontents_of_a_dictionary_are_checked_against_an_empty_list_of_keys_it_should_throw_clear_explanation()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().NotContainKeys(new int[0]);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<ArgumentException>().WithMessage(
+                "Cannot verify key containment against an empty sequence");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -1314,7 +1314,7 @@ namespace FluentAssertions.Specs
         }
         
         [TestMethod]
-        public void When_dictionary_does_not_contain_multiple_values_from_the_dictionary_should_not_throw()
+        public void When_dictionary_does_not_contain_multiple_values_that_is_not_in_the_dictionary_it_should_not_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange

--- a/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -1102,7 +1102,8 @@ namespace FluentAssertions.Specs
                 "Expected dictionary {[1, One], [2, Two]} to contain value \"Three\" because we do.");
         }
 
-        [TestMethod] public void When_a_dictionary_does_not_contain_a_number_of_values_it_should_throw_with_clear_explanation()
+        [TestMethod]
+        public void When_a_dictionary_does_not_contain_a_number_of_values_it_should_throw_with_clear_explanation()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -1146,7 +1147,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<ArgumentException>().WithMessage(
-                "Cannot verify value containment against an empty dictionary");
+                "Cannot verify value containment with an empty sequence");
         }
 
         [TestMethod]
@@ -1203,6 +1204,65 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
                 "Expected dictionary not to contain value \"One\" because we want to test the behaviour with a null subject, but found <null>.");
+        }
+        
+        [TestMethod]
+        public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_values_from_the_dictionary()
+        {
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+            dictionary.Should().NotContainValues("Three", "Four");
+        }
+        
+        [TestMethod]
+        public void When_a_dictionary_contains_a_number_of_values_it_should_throw_with_clear_explanation()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().NotContainValues(new[] { "Two", "Three" }, "because {0}", "we do");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().WithMessage(
+                "Expected dictionary {[1, One], [2, Two]} to not contain value {\"Two\", \"Three\"} because we do, but found {\"Two\"}.");
+        }
+
+        [TestMethod]
+        public void When_the_noncontents_of_a_dictionary_are_checked_against_an_empty_list_of_values_it_should_throw_clear_explanation()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => dictionary.Should().NotContainValues(new string[0]);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<ArgumentException>().WithMessage(
+                "Cannot verify value containment with an empty sequence");
         }
 
         #endregion


### PR DESCRIPTION
This should fix issue https://github.com/dennisdoomen/FluentAssertions/issues/426. I also added more NotContain methods to align Contain and NotContain overloads more.

Being completely new to Git and Github, just let me know if I need to change something