### PR TITLE
Add collection assertion overloads for IComparer<T>

### DIFF
--- a/Src/Core/Collections/CollectionAssertions.cs
+++ b/Src/Core/Collections/CollectionAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Collections
         /// Asserts that the collection does not contain any items.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -44,7 +44,7 @@ namespace FluentAssertions.Collections
         /// Asserts that the collection contains at least 1 item.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -73,7 +73,7 @@ namespace FluentAssertions.Collections
         /// Asserts that the collection is null or does not contain any items.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -96,7 +96,7 @@ namespace FluentAssertions.Collections
         /// Asserts that the collection is not null and contains at least 1 item.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -112,7 +112,7 @@ namespace FluentAssertions.Collections
         /// Asserts that the collection does not contain any duplicate items.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -146,7 +146,7 @@ namespace FluentAssertions.Collections
         /// Asserts that the collection does not contain any <c>null</c> items.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -176,7 +176,7 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Expects the current collection to contain all the same elements in the same order as the collection identified by 
+        /// Expects the current collection to contain all the same elements in the same order as the collection identified by
         /// <paramref name="elements" />. Elements are compared using their <see cref="object.Equals(object)" />.
         /// </summary>
         /// <param name="elements">A params array with the expected elements.</param>
@@ -186,12 +186,12 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Expects the current collection to contain all the same elements in the same order as the collection identified by 
+        /// Expects the current collection to contain all the same elements in the same order as the collection identified by
         /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.
         /// </summary>
         /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -237,12 +237,12 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Expects the current collection not to contain all the same elements in the same order as the collection identified by 
+        /// Expects the current collection not to contain all the same elements in the same order as the collection identified by
         /// <paramref name="unexpected" />. Elements are compared using their <see cref="object.Equals(object)" />.
         /// </summary>
         /// <param name="unexpected">An <see cref="IEnumerable"/> with the elements that are not expected.</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -290,7 +290,7 @@ namespace FluentAssertions.Collections
         /// </summary>
         /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -370,7 +370,7 @@ namespace FluentAssertions.Collections
         /// </summary>
         /// <param name="unexpected">An <see cref="IEnumerable"/> with the unexpected elements.</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -412,7 +412,7 @@ namespace FluentAssertions.Collections
         /// Asserts that the current collection only contains items that are assignable to the type <typeparamref name="T" />.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -475,7 +475,7 @@ namespace FluentAssertions.Collections
         /// </summary>
         /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -549,11 +549,11 @@ namespace FluentAssertions.Collections
         /// Expects the current collection to contain the specified elements in the exact same order, not necessarily consecutive.
         /// </summary>
         /// <remarks>
-        /// Elements are compared using their <see cref="object.Equals(object)" /> implementation. 
+        /// Elements are compared using their <see cref="object.Equals(object)" /> implementation.
         /// </remarks>
         /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -603,7 +603,7 @@ namespace FluentAssertions.Collections
         /// using their <see cref="IComparable.CompareTo(object)" /> implementation.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -611,7 +611,26 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> BeInAscendingOrder(string because = "", params object[] becauseArgs)
         {
-            return BeInOrder(SortOrder.Ascending, because, becauseArgs);
+            return BeInAscendingOrder(Comparer<object>.Default, because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Expects the current collection to have all elements in ascending order. Elements are compared
+        /// using the given <see cref="IComparer{T}" /> implementation.
+        /// </summary>
+        /// <param name="comparer">
+        /// The object that should be used to determine the expected ordering.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeInAscendingOrder(IComparer<object> comparer, string because = "", params object[] becauseArgs)
+        {
+            return BeInOrder(comparer, SortOrder.Ascending, because, becauseArgs);
         }
 
         /// <summary>
@@ -619,7 +638,7 @@ namespace FluentAssertions.Collections
         /// using their <see cref="IComparable.CompareTo(object)" /> implementation.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -627,14 +646,34 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> BeInDescendingOrder(string because = "", params object[] becauseArgs)
         {
-            return BeInOrder(SortOrder.Descending, because, becauseArgs);
+            return BeInDescendingOrder(Comparer<object>.Default, because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Expects the current collection to have all elements in descending order. Elements are compared
+        /// using the given <see cref="IComparer{T}" /> implementation.
+        /// </summary>
+        /// <param name="comparer">
+        /// The object that should be used to determine the expected ordering.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeInDescendingOrder(IComparer<object> comparer, string because = "", params object[] becauseArgs)
+        {
+            return BeInOrder(comparer, SortOrder.Descending, because, becauseArgs);
         }
 
         /// <summary>
         /// Expects the current collection to have all elements in the specified <paramref name="expectedOrder"/>.
         /// Elements are compared using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
-        private AndConstraint<TAssertions> BeInOrder(SortOrder expectedOrder, string because = "", params object[] becauseArgs)
+        private AndConstraint<TAssertions> BeInOrder(
+            IComparer<object> comparer, SortOrder expectedOrder, string because = "", params object[] becauseArgs)
         {
             string sortOrder = (expectedOrder == SortOrder.Ascending) ? "ascending" : "descending";
 
@@ -649,8 +688,8 @@ namespace FluentAssertions.Collections
             object[] actualItems = Subject.Cast<object>().ToArray();
 
             object[] orderedItems = (expectedOrder == SortOrder.Ascending)
-                ? actualItems.OrderBy(item => item).ToArray()
-                : actualItems.OrderByDescending(item => item).ToArray();
+                ? actualItems.OrderBy(item => item, comparer).ToArray()
+                : actualItems.OrderByDescending(item => item, comparer).ToArray();
 
             for (int index = 0; index < orderedItems.Length; index++)
             {
@@ -670,7 +709,7 @@ namespace FluentAssertions.Collections
         /// using their <see cref="IComparable.CompareTo(object)" /> implementation.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -678,7 +717,26 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotBeAscendingInOrder(string because = "", params object[] becauseArgs)
         {
-            return NotBeInOrder(SortOrder.Ascending, because, becauseArgs);
+            return NotBeAscendingInOrder(Comparer<object>.Default, because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts the current collection does not have all elements in ascending order. Elements are compared
+        /// using their <see cref="IComparable.CompareTo(object)" /> implementation.
+        /// </summary>
+        /// <param name="comparer">
+        /// The object that should be used to determine the expected ordering.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeAscendingInOrder(IComparer<object> comparer, string because = "", params object[] becauseArgs)
+        {
+            return NotBeInOrder(comparer, SortOrder.Ascending, because, becauseArgs);
         }
 
         /// <summary>
@@ -686,7 +744,7 @@ namespace FluentAssertions.Collections
         /// using their <see cref="IComparable.CompareTo(object)" /> implementation.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -694,14 +752,33 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotBeDescendingInOrder(string because = "", params object[] becauseArgs)
         {
-            return NotBeInOrder(SortOrder.Descending, because, becauseArgs);
+            return NotBeDescendingInOrder(Comparer<object>.Default, because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts the current collection does not have all elements in descending order. Elements are compared
+        /// using their <see cref="IComparable.CompareTo(object)" /> implementation.
+        /// </summary>
+        /// <param name="comparer">
+        /// The object that should be used to determine the expected ordering.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeDescendingInOrder(IComparer<object> comparer, string because = "", params object[] becauseArgs)
+        {
+            return NotBeInOrder(comparer, SortOrder.Descending, because, becauseArgs);
         }
 
         /// <summary>
         /// Asserts the current collection does not have all elements in ascending order. Elements are compared
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
-        private AndConstraint<TAssertions> NotBeInOrder(SortOrder order, string because = "", params object[] becauseArgs)
+        private AndConstraint<TAssertions> NotBeInOrder(IComparer<object> comparer, SortOrder order, string because = "", params object[] becauseArgs)
         {
             string sortOrder = (order == SortOrder.Ascending) ? "ascending" : "descending";
 
@@ -715,8 +792,8 @@ namespace FluentAssertions.Collections
             }
 
             object[] orderedItems = (order == SortOrder.Ascending)
-                ? Subject.Cast<object>().OrderBy(item => item).ToArray()
-                : Subject.Cast<object>().OrderByDescending(item => item).ToArray();
+                ? Subject.Cast<object>().OrderBy(item => item, comparer).ToArray()
+                : Subject.Cast<object>().OrderByDescending(item => item, comparer).ToArray();
 
             object[] actualItems = Subject.Cast<object>().ToArray();
 
@@ -740,8 +817,8 @@ namespace FluentAssertions.Collections
         /// Asserts that the collection is a subset of the <paramref name="expectedSuperset" />.
         /// </summary>
         /// <param name="expectedSuperset">An <see cref="IEnumerable"/> with the expected superset.</param>
-        /// <param name="because">        
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -785,7 +862,7 @@ namespace FluentAssertions.Collections
         /// </summary>
         /// <param name="unexpectedSuperset">An <see cref="IEnumerable"/> with the unexpected superset.</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -817,7 +894,7 @@ namespace FluentAssertions.Collections
         /// </summary>
         /// <param name="otherCollection">The other collection with the same expected number of elements</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -854,13 +931,13 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Asserts that the current collection has the supplied <paramref name="element" /> at the 
+        /// Asserts that the current collection has the supplied <paramref name="element" /> at the
         /// supplied <paramref name="index" />.
         /// </summary>
         /// <param name="index">The index where the element is expected</param>
         /// <param name="element">The expected element</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -904,7 +981,7 @@ namespace FluentAssertions.Collections
         /// </summary>
         /// <param name="unexpected">An <see cref="IEnumerable"/> with the unexpected elements.</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -969,7 +1046,7 @@ namespace FluentAssertions.Collections
         /// </summary>
         /// <param name="otherCollection">The <see cref="IEnumerable"/> with the expected shared items.</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -1011,7 +1088,7 @@ namespace FluentAssertions.Collections
         /// </summary>
         /// <param name="otherCollection">The <see cref="IEnumerable"/> to compare to.</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -1056,7 +1133,7 @@ namespace FluentAssertions.Collections
         /// is used to compare the element.
         /// </param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -1089,7 +1166,7 @@ namespace FluentAssertions.Collections
         /// is used to compare the element.
         /// </param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -1123,7 +1200,7 @@ namespace FluentAssertions.Collections
         /// Asserts that the <paramref name="expectation"/> element directly precedes the <paramref name="successor"/>.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -1147,7 +1224,7 @@ namespace FluentAssertions.Collections
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
-        
+
         private bool HasPredecessor(object successor, IEnumerable<object> subject)
         {
             return !ReferenceEquals(subject.First(), successor);
@@ -1159,12 +1236,12 @@ namespace FluentAssertions.Collections
             int index = Array.IndexOf(collection, succesor);
             return (index > 0) ? collection[index - 1] : null;
         }
-        
+
         /// <summary>
         /// Asserts that the <paramref name="expectation"/> element directly succeeds the <paramref name="predecessor"/>.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">

--- a/Src/Core/Collections/GenericCollectionAssertions.cs
+++ b/Src/Core/Collections/GenericCollectionAssertions.cs
@@ -18,69 +18,164 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Asserts that a collection is ordered in ascending order according to the value of the the specified 
+        /// Asserts that a collection is ordered in ascending order according to the value of the specified
         /// <paramref name="propertyExpression"/>.
         /// </summary>
         /// <param name="propertyExpression">
         /// A lambda expression that references the property that should be used to determine the expected ordering.
         /// </param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="args">
+        /// Zero or more objects to format using the placeholders in <see cref="because"/>.
+        /// </param>
+        public AndConstraint<GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(
+            Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] args)
+        {
+            return BeInAscendingOrder(propertyExpression, Comparer<TSelector>.Default, because, args);
+        }
+
+        /// <summary>
+        /// Asserts that a collection is ordered in ascending order according to the value of the specified
+        /// <see cref="IComparer{T}"/> implementation.
+        /// </summary>
+        /// <param name="comparer">
+        /// The object that should be used to determine the expected ordering.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="args">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public AndConstraint<GenericCollectionAssertions<T>> BeInAscendingOrder(
-            Expression<Func<T, object>> propertyExpression, string because = "", params object[] args)
+            IComparer<T> comparer, string because = "", params object[] args)
         {
-            return BeOrderedBy(propertyExpression, SortDirection.Ascending, because, args);
+            return BeInAscendingOrder(item => item, comparer, because, args);
         }
 
         /// <summary>
-        /// Asserts that a collection is ordered in descending order according to the value of the the specified 
+        /// Asserts that a collection is ordered in ascending order according to the value of the specified
+        /// <paramref name="propertyExpression"/> and <see cref="IComparer{T}"/> implementation.
+        /// </summary>
+        /// <param name="propertyExpression">
+        /// A lambda expression that references the property that should be used to determine the expected ordering.
+        /// </param>
+        /// <param name="comparer">
+        /// The object that should be used to determine the expected ordering.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="args">
+        /// Zero or more objects to format using the placeholders in <see cref="because"/>.
+        /// </param>
+        public AndConstraint<GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(
+            Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] args)
+        {
+            return BeOrderedBy(propertyExpression, comparer, SortDirection.Ascending, because, args);
+        }
+
+        /// <summary>
+        /// Asserts that a collection is ordered in descending order according to the value of the specified
         /// <paramref name="propertyExpression"/>.
         /// </summary>
         /// <param name="propertyExpression">
         /// A lambda expression that references the property that should be used to determine the expected ordering.
         /// </param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="args">
+        /// Zero or more objects to format using the placeholders in <see cref="because"/>.
+        /// </param>
+        public AndConstraint<GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(
+            Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] args)
+        {
+            return BeInDescendingOrder(propertyExpression, Comparer<TSelector>.Default, because, args);
+        }
+
+        /// <summary>
+        /// Asserts that a collection is ordered in descending order according to the value of the specified
+        /// <see cref="IComparer{T}"/> implementation.
+        /// </summary>
+        /// <param name="comparer">
+        /// The object that should be used to determine the expected ordering.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="args">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
         public AndConstraint<GenericCollectionAssertions<T>> BeInDescendingOrder(
-            Expression<Func<T, object>> propertyExpression, string because = "", params object[] args)
+            IComparer<T> comparer, string because = "", params object[] args)
         {
-            return BeOrderedBy(propertyExpression, SortDirection.Descending, because, args);
+            return BeInDescendingOrder(item => item, comparer, because, args);
         }
 
-        private AndConstraint<GenericCollectionAssertions<T>> BeOrderedBy(
-            Expression<Func<T, object>> propertyExpression, SortDirection direction, string because, object[] args)
+        /// <summary>
+        /// Asserts that a collection is ordered in descending order according to the value of the specified
+        /// <paramref name="propertyExpression"/> and <see cref="IComparer{T}"/> implementation.
+        /// </summary>
+        /// <param name="propertyExpression">
+        /// A lambda expression that references the property that should be used to determine the expected ordering.
+        /// </param>
+        /// <param name="comparer">
+        /// The object that should be used to determine the expected ordering.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="args">
+        /// Zero or more objects to format using the placeholders in <see cref="because"/>.
+        /// </param>
+        public AndConstraint<GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(
+            Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] args)
         {
+            return BeOrderedBy(propertyExpression, comparer, SortDirection.Descending, because, args);
+        }
+
+        private AndConstraint<GenericCollectionAssertions<T>> BeOrderedBy<TSelector>(
+            Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, SortDirection direction, string because, object[] args)
+        {
+            if (comparer == null)
+            {
+                throw new ArgumentNullException("comparer",
+                    "Cannot assert collection ordering without specifying a comparer.");
+            }
+
             if (IsValidProperty(propertyExpression, because, args))
             {
                 IList<T> unordered = (Subject as IList<T>) ?? Subject.ToList();
 
-                Func<T, object> keySelector = propertyExpression.Compile();
+                Func<T, TSelector> keySelector = propertyExpression.Compile();
 
                 IOrderedEnumerable<T> expectation = (direction == SortDirection.Ascending)
-                    ? unordered.OrderBy(keySelector)
-                    : unordered.OrderByDescending(keySelector);
+                    ? unordered.OrderBy(keySelector, comparer)
+                    : unordered.OrderByDescending(keySelector, comparer);
+
+                var orderString = propertyExpression.GetMemberPath();
+                orderString = orderString == "\"\"" ? string.Empty : " by " + orderString;
 
                 Execute.Assertion
                     .ForCondition(unordered.SequenceEqual(expectation))
                     .BecauseOf(because, args)
-                    .FailWith("Expected collection {0} to be ordered by {1}{reason} and result in {2}.",
-                        Subject, propertyExpression.GetMemberPath(), expectation);
+                    .FailWith("Expected collection {0} to be ordered{1}{reason} and result in {2}.",
+                        Subject, orderString, expectation);
             }
-            
+
             return new AndConstraint<GenericCollectionAssertions<T>>(this);
         }
 
-        private bool IsValidProperty(Expression<Func<T, object>> propertyExpression, string because, object[] args)
+        private bool IsValidProperty<TSelector>(Expression<Func<T, TSelector>> propertyExpression, string because, object[] args)
         {
             if (propertyExpression == null)
             {

--- a/Src/Core/Collections/GenericCollectionAssertions.cs
+++ b/Src/Core/Collections/GenericCollectionAssertions.cs
@@ -77,7 +77,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] args)
         {
-            return BeOrderedBy(propertyExpression, comparer, SortDirection.Ascending, because, args);
+            return BeOrderedBy(propertyExpression, comparer, SortOrder.Ascending, because, args);
         }
 
         /// <summary>
@@ -140,11 +140,11 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] args)
         {
-            return BeOrderedBy(propertyExpression, comparer, SortDirection.Descending, because, args);
+            return BeOrderedBy(propertyExpression, comparer, SortOrder.Descending, because, args);
         }
 
         private AndConstraint<GenericCollectionAssertions<T>> BeOrderedBy<TSelector>(
-            Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, SortDirection direction, string because, object[] args)
+            Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, SortOrder direction, string because, object[] args)
         {
             if (comparer == null)
             {
@@ -158,7 +158,7 @@ namespace FluentAssertions.Collections
 
                 Func<T, TSelector> keySelector = propertyExpression.Compile();
 
-                IOrderedEnumerable<T> expectation = (direction == SortDirection.Ascending)
+                IOrderedEnumerable<T> expectation = (direction == SortOrder.Ascending)
                     ? unordered.OrderBy(keySelector, comparer)
                     : unordered.OrderByDescending(keySelector, comparer);
 
@@ -188,12 +188,6 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, args)
                 .FailWith("Expected collection to be ordered by {0}{reason} but found <null>.",
                     propertyExpression.GetMemberPath());
-        }
-
-        private enum SortDirection
-        {
-            Ascending,
-            Descending
         }
     }
 }

--- a/Tests/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
@@ -132,7 +132,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => collection.Should().HaveCount(4, "because we want to test the failure {0}", "message");
-            
+
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
@@ -251,7 +251,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            collection.GetEnumeratorCallCount.Should().Be(1); 
+            collection.GetEnumeratorCallCount.Should().Be(1);
         }
 
         [TestMethod]
@@ -458,7 +458,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
             collection.GetEnumeratorCallCount.Should().Be(1);
-            
+
         }
 
         #endregion
@@ -788,7 +788,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             IEnumerable collection1 = new [] { new []{1, 2}, new[]{3, 4} };
             IEnumerable collection2 = new [] { new []{5, 6}, new[]{7, 8} };
-            
+
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
@@ -864,20 +864,20 @@ namespace FluentAssertions.Specs
                 "Expected collection to be equal to {1, 2, 3}, but found empty collection.");
         }
 
-        [TestMethod] 
-        public void When_all_items_match_according_to_a_predicate_it_should_succeed() 
-        { 
+        [TestMethod]
+        public void When_all_items_match_according_to_a_predicate_it_should_succeed()
+        {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-           var actual = new List<string> { "ONE", "TWO", "THREE", "FOUR" }; 
+           var actual = new List<string> { "ONE", "TWO", "THREE", "FOUR" };
            var expected = new []
            {
                new { Value = "One" },
                new { Value = "Two" },
                new { Value = "Three" },
                new { Value = "Four" }
-           }; 
+           };
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -1190,7 +1190,7 @@ namespace FluentAssertions.Specs
             act.ShouldThrow<AssertFailedException>().WithMessage(
                 "*collection {1, 2, 3} to be equivalent to {1, 2}*too many*");
         }
-        
+
         [TestMethod]
         public void When_collections_with_duplicates_are_not_equivalent_it_should_throw()
         {
@@ -1232,7 +1232,7 @@ namespace FluentAssertions.Specs
             act.ShouldThrow<AssertFailedException>().WithMessage(
                 "*collection {1, 2, 3} to be equivalent to {empty}, but*");
         }
-        
+
         [TestMethod]
         public void When_two_collections_are_both_empty_it_should_treat_them_as_equivalent()
         {
@@ -1310,7 +1310,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             collection1.Should().NotBeEquivalentTo(collection2);
         }
-        
+
         [TestMethod]
         public void When_collection_is_not_equivalent_to_another_equally_sized_collection_it_should_succeed()
         {
@@ -1507,7 +1507,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             subject.Should().NotBeSubsetOf(otherSet);
         }
-        
+
         [TestMethod]
         public void When_an_empty_set_is_not_supposed_to_be_a_subset_of_another_set_it_should_throw()
         {
@@ -1688,7 +1688,7 @@ namespace FluentAssertions.Specs
             IEnumerable<int> collection = new[] { 1, 2, 3 };
             collection.Should().NotContain(new[] { 4, 5 });
         }
-        
+
         [TestMethod]
         public void When_collection_contains_an_unexpected_item_it_should_throw()
         {
@@ -1763,7 +1763,7 @@ namespace FluentAssertions.Specs
             act.ShouldThrow<AssertFailedException>().WithMessage(
                 "Expected collection to not contain {1} because we want to test the behaviour with a null subject, but found <null>.");
         }
-        
+
         [TestMethod]
         public void When_collection_contains_unexpected_items_it_should_throw()
         {
@@ -1939,7 +1939,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_it_should_succeed()
         {
-            //-----------------------------------------------------------------------------------------------------------      
+            //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             IEnumerable collection = new[] { 1, 2, 2, 3 };
@@ -1948,6 +1948,20 @@ namespace FluentAssertions.Specs
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
             collection.Should().BeInAscendingOrder();
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { 1, 2, 2, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().BeInAscendingOrder(Comparer<object>.Default);
         }
 
         [TestMethod]
@@ -1972,6 +1986,27 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { 1, 6, 12, 15, 12, 17, 26 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => collection.Should().BeInAscendingOrder(Comparer<object>.Default, "because numbers are ordered");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected collection to contain items in ascending order because numbers are ordered," +
+                    " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
+        }
+
+        [TestMethod]
         public void When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -1983,6 +2018,20 @@ namespace FluentAssertions.Specs
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
             collection.Should().NotBeAscendingInOrder();
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { 1, 5, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().NotBeAscendingInOrder(Comparer<object>.Default);
         }
 
         [TestMethod]
@@ -2007,9 +2056,30 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { 1, 2, 2, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => collection.Should().NotBeAscendingInOrder(Comparer<object>.Default, "because numbers are not ordered");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<AssertFailedException>()
+                .WithMessage("Did not expect collection to contain items in ascending order because numbers are not ordered," +
+                    " but found {1, 2, 2, 3}.");
+        }
+
+        [TestMethod]
         public void When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_it_should_succeed()
         {
-            //-----------------------------------------------------------------------------------------------------------      
+            //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             IEnumerable collection = new[] { "z", "y", "x" };
@@ -2018,6 +2088,20 @@ namespace FluentAssertions.Specs
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
             collection.Should().BeInDescendingOrder();
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_using_the_given_comparer_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { "z", "y", "x" };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().BeInDescendingOrder(Comparer<object>.Default);
         }
 
         [TestMethod]
@@ -2042,6 +2126,27 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_using_the_given_comparer_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { "z", "x", "y" };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => collection.Should().BeInDescendingOrder(Comparer<object>.Default, "because letters are ordered");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected collection to contain items in descending order because letters are ordered," +
+                    " but found {\"z\", \"x\", \"y\"} where item at index 1 is in wrong order.");
+        }
+
+        [TestMethod]
         public void When_asserting_the_items_in_an_unordered_collection_are_not_in_descending_order_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -2053,6 +2158,20 @@ namespace FluentAssertions.Specs
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
             collection.Should().NotBeDescendingInOrder();
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_unordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { "x", "y", "x" };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().NotBeDescendingInOrder(Comparer<object>.Default);
         }
 
         [TestMethod]
@@ -2076,6 +2195,27 @@ namespace FluentAssertions.Specs
                     " but found {\"c\", \"b\", \"a\"}.");
         }
 
+        [TestMethod]
+        public void When_asserting_the_items_in_a_descending_ordered_collection_are_not_in_descending_order_using_the_given_comparer_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { "c", "b", "a" };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => collection.Should().NotBeDescendingInOrder(Comparer<object>.Default, "because numbers are not ordered");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<AssertFailedException>()
+                .WithMessage("Did not expect collection to contain items in descending order because numbers are not ordered," +
+                    " but found {\"c\", \"b\", \"a\"}.");
+        }
+
         #endregion
 
         #region (Not) Intersect
@@ -2083,7 +2223,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void When_asserting_the_items_in_an_two_intersecting_collections_intersect_it_should_succeed()
         {
-            //-----------------------------------------------------------------------------------------------------------      
+            //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             IEnumerable collection = new[] { 1, 2, 3 };
@@ -2098,7 +2238,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void When_asserting_the_items_in_an_two_non_intersecting_collections_intersect_it_should_throw()
         {
-            //-----------------------------------------------------------------------------------------------------------      
+            //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             IEnumerable collection = new[] { 1, 2, 3 };
@@ -2120,7 +2260,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void When_asserting_the_items_in_an_two_non_intersecting_collections_do_not_intersect_it_should_succeed()
         {
-            //-----------------------------------------------------------------------------------------------------------      
+            //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             IEnumerable collection = new[] { 1, 2, 3 };
@@ -2135,7 +2275,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void When_asserting_the_items_in_an_two_intersecting_collections_do_not_intersect_it_should_throw()
         {
-            //-----------------------------------------------------------------------------------------------------------      
+            //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             IEnumerable collection = new[] { 1, 2, 3 };
@@ -2231,7 +2371,7 @@ namespace FluentAssertions.Specs
                 1,
                 "2"
             };
-            
+
             Action act = () => collection.Should().ContainItemsAssignableTo<string>();
 
             act.ShouldThrow<AssertFailedException>();
@@ -2846,7 +2986,7 @@ namespace FluentAssertions.Specs
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
-            //-----------------------------------------------------------------------------------------------------------            
+            //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
                 "Expected 3 at index 4 because we put it there, but found no element.");
         }
@@ -2916,7 +3056,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "cris", "mick", "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementPreceding("mick", "cris");
 
@@ -2935,7 +3075,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "cris", "mick", "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementPreceding("john", "cris", "because of some reason");
 
@@ -2955,7 +3095,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "cris", "mick", "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementPreceding("cris", "jane");
 
@@ -2975,7 +3115,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new string[0];
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementPreceding("mick", "cris");
 
@@ -2985,7 +3125,7 @@ namespace FluentAssertions.Specs
             act.ShouldThrow<AssertFailedException>()
                 .WithMessage("Expected*cris*precede*mick*collection*empty*");
         }
-        
+
         [TestMethod]
         public void When_a_null_element_is_preceding_another_element_it_should_not_throw()
         {
@@ -2995,7 +3135,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { null, "mick", "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementPreceding("mick", null);
 
@@ -3004,7 +3144,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldNotThrow();
         }
-        
+
         [TestMethod]
         public void When_a_null_element_is_not_preceding_another_element_it_should_throw()
         {
@@ -3014,7 +3154,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "cris", "mick", "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementPreceding("mick", null);
 
@@ -3034,7 +3174,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "mick", null, "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementPreceding(null, "mick");
 
@@ -3053,7 +3193,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "mick", null, "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementPreceding(null, "cris");
 
@@ -3077,7 +3217,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "cris", "mick", "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementSucceeding("cris", "mick");
 
@@ -3096,7 +3236,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "cris", "mick", "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementSucceeding("mick", "cris", "because of some reason");
 
@@ -3116,7 +3256,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "cris", "mick", "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementSucceeding("john", "jane");
 
@@ -3136,7 +3276,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new string[0];
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementSucceeding("mick", "cris");
 
@@ -3156,7 +3296,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "mick", null, "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementSucceeding("mick", null);
 
@@ -3175,7 +3315,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "cris", "mick", "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementSucceeding("mick", null);
 
@@ -3195,7 +3335,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "mick", null, "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementSucceeding(null, "john");
 
@@ -3214,7 +3354,7 @@ namespace FluentAssertions.Specs
             IEnumerable collection = new[] { "mick", null, "john" };
 
             //-----------------------------------------------------------------------------------------------------------
-            // Act 
+            // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => collection.Should().HaveElementSucceeding(null, "cris");
 

--- a/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionsSpecs.cs
@@ -577,10 +577,10 @@ namespace FluentAssertions.Specs
 
         #endregion
 
-        #region Be In Ascending/Decending Order
+        #region Be In Ascending/Descending Order
 
         [TestMethod]
-        public void When_the_items_are_not_in_ascending_order_using_the_specified_property_it_should_throw()
+        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_specified_property_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -605,7 +605,52 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_the_items_are_in_ascending_order_using_the_specified_property_it_should_not_throw()
+        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[] { 2, 3, 1 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInAscendingOrder(Comparer<int>.Default, "it should be sorted");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected collection*2*3*1*ordered*should be sorted*1*2*3*");
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[]
+            {
+                new { Text = "b", Numeric = 1 },
+                new { Text = "c", Numeric = 2 },
+                new { Text = "a", Numeric = 3 }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should be sorted");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected collection*b*c*a*ordered*Text*should be sorted*a*b*c*");
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_specified_property_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -629,7 +674,50 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_the_items_are_not_in_descending_order_using_the_specified_property_it_should_throw()
+        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[] { 1, 2, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInAscendingOrder(Comparer<int>.Default);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[]
+            {
+                new { Text = "b", Numeric = 1 },
+                new { Text = "c", Numeric = 2 },
+                new { Text = "a", Numeric = 3 }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInAscendingOrder(o => o.Numeric, Comparer<int>.Default);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_using_the_specified_property_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -654,7 +742,52 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_the_items_are_in_descending_order_using_the_specified_property_it_should_not_throw()
+        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_using_the_given_comparer_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[] { 1, 2, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInDescendingOrder(Comparer<int>.Default, "it should be sorted");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected collection*1*2*3*ordered*should be sorted*3*2*1*");
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_unordered_collection_are_ordered_descending_using_the_specified_property_and_the_given_comparer_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[]
+            {
+                new { Text = "b", Numeric = 1 },
+                new { Text = "c", Numeric = 2 },
+                new { Text = "a", Numeric = 3 }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInDescendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should be sorted");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected collection*b*c*a*ordered*Text*should be sorted*c*b*a*");
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_using_the_specified_property_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -678,7 +811,50 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_the_collection_is_empty_while_asserting_a_particular_order_it_should_not_throw()
+        public void When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_using_the_given_comparer_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[] { 3, 2, 1 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInDescendingOrder(Comparer<int>.Default);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_descendingly_ordered_collection_are_ordered_descending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[]
+            {
+                new { Text = "b", Numeric = 3 },
+                new { Text = "c", Numeric = 2 },
+                new { Text = "a", Numeric = 1 }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInDescendingOrder(o => o.Numeric, Comparer<int>.Default);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_empty_collection_are_ordered_ascending_using_the_specified_property_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -697,7 +873,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_the_collection_is_null_while_asserting_a_particular_order_it_should_fail()
+        public void When_asserting_the_items_in_an_empty_collection_are_ordered_ascending_using_the_given_comparer_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -707,7 +883,45 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => collection.Should().BeInAscendingOrder(null);
+            Action act = () => collection.Should().BeInAscendingOrder(Comparer<SomeClass>.Default);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_an_empty_collection_are_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = Enumerable.Empty<SomeClass>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_a_collection_are_ordered_and_the_specified_property_is_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = Enumerable.Empty<SomeClass>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInAscendingOrder((Expression<Func<SomeClass, string>>)null);
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -717,7 +931,27 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_the_order_of_a_collection_without_specifying_a_property_it_should_throw()
+        public void When_asserting_the_items_in_a_collection_are_ordered_and_the_given_comparer_is_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = Enumerable.Empty<SomeClass>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInAscendingOrder((IComparer<SomeClass>)null);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<ArgumentNullException>()
+                .WithMessage("Cannot assert collection ordering without specifying a comparer*comparer*");
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_a_null_collection_are_ordered_using_the_specified_property_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -737,12 +971,52 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_the_order_of_a_collection_with_an_invalid_property_expression_it_should_throw()
+        public void When_asserting_the_items_in_a_null_collection_are_ordered_using_the_given_comparer_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             const IEnumerable<SomeClass> collection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInAscendingOrder(Comparer<SomeClass>.Default);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected*found*null*");
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_a_null_collection_are_ordered_using_the_specified_property_and_the_given_comparer_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const IEnumerable<SomeClass> collection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().BeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected*Text*found*null*");
+        }
+
+        [TestMethod]
+        public void When_asserting_the_items_in_ay_collection_are_ordered_using_an_invalid_property_expression_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = Enumerable.Empty<SomeClass>();
 
             //-----------------------------------------------------------------------------------------------------------
             // Act


### PR DESCRIPTION
Create overloads of `.Should().BeInAscendingOrder(...)` and all related methods, specifically in the `CollectionAssertions` and `GenericCollectionAssertions` classes. Custom `IComparer<T>` objects can now be passed in.

Unit tests are included for the new methods. It also looks like my VS chopped off a bunch of trailing whitespace chars; hope that's not a problem. :)