### PR TITLE
fix for issue #468; bug in how dictionaries are compared. 

### DIFF
--- a/Src/Core/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/Core/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -43,8 +43,16 @@ namespace FluentAssertions.Equivalency
             Type subjectType = config.GetSubjectType(context);
 
             return (AssertImplementsOnlyOneDictionaryInterface(context.Subject)
+                    && AssertExpectationIsNotNull(context.Subject, context.Expectation)
                     && AssertIsCompatiblyTypedDictionary(subjectType, context.Expectation)
                     && AssertSameLength(context.Subject, subjectType, context.Expectation));
+        }
+
+        private static bool AssertExpectationIsNotNull(object subject, object expectation)
+        {
+            return AssertionScope.Current
+                .ForCondition(!ReferenceEquals(expectation, null))
+                .FailWith("Expected {context:Subject} to be {0}, but found {1}.", null, subject);
         }
 
         private static bool AssertImplementsOnlyOneDictionaryInterface(object subject)

--- a/Tests/FluentAssertions.Shared.Specs/DictionaryEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/DictionaryEquivalencySpecs.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace FluentAssertions.Specs
 {
+   
     [TestClass]
     public class DictionaryEquivalencySpecs
     {
@@ -751,6 +752,65 @@ namespace FluentAssertions.Specs
                 .WithMessage("Member*Customers*dictionary*non-dictionary*");
         }
 
+        [TestMethod]
+        public void When_the_other_property_is_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var expected = new ClassWithMemberDictionary
+            {
+                Dictionary = null
+            };
+
+            var subject = new ClassWithMemberDictionary
+            {
+                Dictionary = new Dictionary<string, string>
+                    {
+                        {"Key2", "Value2"},
+                        {"Key1", "Value1"}
+                    }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.ShouldBeEquivalentTo(expected);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("*member*Dictionary to be <null>, but found *{*}*");
+        }
+
+        [TestMethod]
+        public void When_the_both_properties_are_null_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var expected = new ClassWithMemberDictionary
+            {
+                Dictionary = null
+            };
+
+            var subject = new ClassWithMemberDictionary
+            {
+                Dictionary = null
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.ShouldBeEquivalentTo(expected);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow<AssertFailedException>();
+        }
+
         [TestMethodAttribute]
         public void
             When_the_other_dictionary_does_not_contain_enough_items_it_should_throw
@@ -952,6 +1012,11 @@ namespace FluentAssertions.Specs
             {
                 innerRoles[userId] = roles.ToList();
             }
+        }
+
+        public class ClassWithMemberDictionary
+        {
+            public Dictionary<string, string> Dictionary { get; set; }
         }
 
         #endregion


### PR DESCRIPTION
fail with a good error message (rather than NullRef) if comparing Dictionary to null