### PR TITLE
Ensured that using the Including construct always starts at the root.

### DIFF
--- a/Src/Core/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
+++ b/Src/Core/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
@@ -23,7 +23,7 @@ namespace FluentAssertions.Equivalency.Selection
         {
             var matchingMembers =
                 from member in context.RuntimeType.GetNonPrivateMembers()
-                where pathToInclude.StartsWith(currentPath.Combine(member.Name))
+                where pathToInclude.IsParentOrChildOf(currentPath.Combine(member.Name))
                 select member;
 
             return selectedMembers.Concat(matchingMembers).ToArray();

--- a/Src/Core/Equivalency/Selection/MemberPath.cs
+++ b/Src/Core/Equivalency/Selection/MemberPath.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace FluentAssertions.Equivalency.Selection
 {
     /// <summary>
-    /// Encapsulates a dotted path to a (nested) member of a type. 
+    /// Encapsulates a dotted candidate to a (nested) member of a type. 
     /// </summary>
     internal class MemberPath
     {
@@ -12,13 +13,29 @@ namespace FluentAssertions.Equivalency.Selection
 
         public MemberPath(string dottedPath)
         {
-            segments.AddRange(dottedPath.Split('.'));
+            segments.AddRange(Segmentize(dottedPath));
         }
 
-        public bool StartsWith(string subPath)
+        public bool IsParentOrChildOf(string candidate)
         {
-            string[] subPathSegments = subPath.Split('.');
-            return segments.Take(subPathSegments.Length).SequenceEqual(subPathSegments);
+            return IsParent(candidate) || IsChild(candidate);
+        }
+
+        private bool IsChild(string candidate)
+        {
+            return Segmentize(candidate).Take(segments.Count).SequenceEqual(segments);
+        }
+
+        private bool IsParent(string candidate)
+        {
+            string[] candidateSegments = Segmentize(candidate);
+
+            return candidateSegments.SequenceEqual(segments.Take(candidateSegments.Length));
+        }
+
+        private static string[] Segmentize(string dottedPath)
+        {
+            return dottedPath.Split(new[] { '.', '[', ']' }, StringSplitOptions.RemoveEmptyEntries);
         }
     }
 }

--- a/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
@@ -574,6 +574,49 @@ With configuration:*");
             act.ShouldNotThrow();
         }
 
+        public class CustomType
+        {
+            public string Name { get; set; }
+        }
+
+        public class ClassA
+        {
+            public List<CustomType> ListOfCustomTypes { get; set; }
+        }
+
+        [TestMethod]
+        public void When_including_a_property_using_an_expression_it_should_evaluate_it_from_the_root()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var list1 = new List<CustomType>
+            {
+                new CustomType {Name = "A"},
+                new CustomType {Name = "B"}
+            };
+
+            var list2 = new List<CustomType>
+            {
+                new CustomType {Name = "C"},
+                new CustomType {Name = "D"}
+            };
+
+            var objectA = new ClassA { ListOfCustomTypes = list1 };
+            var objectB = new ClassA { ListOfCustomTypes = list2 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => objectA.ShouldBeEquivalentTo(objectB, options => options.Including(x => x.ListOfCustomTypes));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>().
+                WithMessage("*C*but*A*D*but*B*");
+        }
+
         [TestMethod]
         public void When_null_is_provided_as_property_expression_it_should_throw()
         {


### PR DESCRIPTION
Fixes #462.