### PR TITLE
Non-generic BeAssignableTo enhancement

### DIFF
--- a/Src/Core/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/Core/Primitives/ReferenceTypeAssertions.cs
@@ -216,6 +216,30 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Asserts that the object is assignable to a variable of given <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The type to which the object should be assignable.</param>
+        /// <param name="because">The parameters used when formatting the <paramref name="because"/>.</param>
+        /// <param name="becauseArgs"></param>
+        /// <returns>An <see cref="AndWhichConstraint{TAssertions, T}"/> which can be used to chain assertions.</returns>
+        public AndConstraint<TAssertions> BeAssignableTo(Type type, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:type} not to be {0}{reason}, but found <null>.", type);
+
+            Execute.Assertion
+                .ForCondition(type.IsAssignableFrom(Subject.GetType()))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:" + Context + "} to be assignable to {0}{reason}, but {1} is not",
+                    type,
+                    Subject.GetType());
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
         /// Asserts that the <paramref name="predicate" /> is satisfied.
         /// </summary>
         /// <param name="predicate">The predicate which must be satisfied by the <typeparamref name="TSubject" />.</param>

--- a/Src/Core/Types/TypeAssertions.cs
+++ b/Src/Core/Types/TypeAssertions.cs
@@ -74,13 +74,25 @@ namespace FluentAssertions.Types
         /// <returns>An <see cref="AndConstraint{T}"/> which can be used to chain assertions.</returns>
         public new AndConstraint<TypeAssertions> BeAssignableTo<T>(string because = "", params object[] becauseArgs)
         {
+            return BeAssignableTo(typeof(T), because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts than an instance of the subject type is assignable variable of given <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The type to which instances of the type should be assignable.</param>
+        /// <param name="because">The reason why instances of the type should be assignable to the type.</param>
+        /// <param name="becauseArgs"></param>
+        /// <returns>An <see cref="AndConstraint{T}"/> which can be used to chain assertions.</returns>
+        public new AndConstraint<TypeAssertions> BeAssignableTo(Type type, string because = "", params object[] becauseArgs)
+        {
             Execute.Assertion
-                .ForCondition(typeof(T).IsAssignableFrom(Subject))
+                .ForCondition(type.IsAssignableFrom(Subject))
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:" + Context + "} {0} to be assignable to {1}{reason}, but it is not",
                     Subject,
-                    typeof(T));
+                    type);
 
             return new AndConstraint<TypeAssertions>(this);
         }

--- a/Src/FluentAssertions.Core.Dotnet/ReflectionExtensions.cs
+++ b/Src/FluentAssertions.Core.Dotnet/ReflectionExtensions.cs
@@ -49,6 +49,9 @@ namespace FluentAssertions
             return type.GetTypeInfo().IsGenericTypeDefinition;
         }
 
+        public static bool IsAssignableFrom(this Type type, Type fromType)
+        {
+            return type.GetTypeInfo().IsAssignableFrom(fromType.GetTypeInfo());
+        }
     }
-
 }

--- a/Tests/FluentAssertions.Shared.Specs/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/ObjectAssertionSpecs.cs
@@ -454,6 +454,68 @@ namespace FluentAssertions.Specs
             act.ShouldThrow<AssertFailedException>().WithMessage("*Expected*Other*Actual*");
         }
 
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_its_own_type_using_type_instance_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            someObject.Should().BeAssignableTo(typeof(DummyImplementingClass));
+        }
+
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_to_its_base_type_using_type_instance_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            someObject.Should().BeAssignableTo(typeof(DummyBaseClass));
+        }
+
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_to_an_implemented_interface_type_using_type_instance_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            someObject.Should().BeAssignableTo(typeof(IDisposable));
+        }
+
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_to_an_unrelated_type_using_type_instance_it_should_fail_with_a_descriptive_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+            Type assignableCheckType = typeof(DateTime);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            someObject.Invoking(
+                x => x.Should().BeAssignableTo(assignableCheckType, "because we want to test the failure {0}", "message"))
+                .ShouldThrow<AssertFailedException>()
+                .WithMessage(string.Format(
+                    "Expected object to be assignable to {1} because we want to test the failure message, but {0} is not",
+                    typeof(DummyImplementingClass), assignableCheckType));
+        }
+
         #endregion
 
         #region HaveFlag / NotHaveFlag

--- a/Tests/FluentAssertions.Shared.Specs/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/ObjectAssertionSpecs.cs
@@ -375,7 +375,7 @@ namespace FluentAssertions.Specs
         #region BeAssignableTo
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_its_own_type_it_should_succeed()
+        public void When_its_own_type_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -389,7 +389,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_its_base_type_it_should_succeed()
+        public void When_its_base_type_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -403,7 +403,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_an_implemented_interface_type_it_should_succeed()
+        public void When_an_implemented_interface_type_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -417,26 +417,23 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_an_unrelated_type_it_should_fail_with_a_descriptive_message()
+        public void When_an_unrelated_type_it_should_fail_with_a_descriptive_message()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             var someObject = new DummyImplementingClass();
+            Action act = () => someObject.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message");
 
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
-            someObject.Invoking(
-                x => x.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message"))
-                .ShouldThrow<AssertFailedException>()
-                .WithMessage(string.Format(
-                    "Expected object to be assignable to {1} because we want to test the failure message, but {0} is not",
-                    typeof(DummyImplementingClass), typeof(DateTime)));
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage($"*assignable to {typeof(DateTime)}*failure message*{typeof(DummyImplementingClass)} is not*");
         }
 
         [TestMethod]
-        public void When_object_is_assignable_to_the_expected_type_it_should_cast_the_returned_object_for_chaining()
+        public void When_to_the_expected_type_it_should_cast_the_returned_object_for_chaining()
         {
             //-------------------------------------------------------------------------------------------------------------------
             // Arrange
@@ -455,7 +452,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_its_own_type_using_type_instance_it_should_succeed()
+        public void When_its_own_type_instance_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -469,7 +466,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_its_base_type_using_type_instance_it_should_succeed()
+        public void When_its_base_type_instance_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -483,7 +480,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_an_implemented_interface_type_using_type_instance_it_should_succeed()
+        public void When_an_implemented_interface_type_instance_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -497,23 +494,19 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_an_unrelated_type_using_type_instance_it_should_fail_with_a_descriptive_message()
+        public void When_an_unrelated_type_instance_it_should_fail_with_a_descriptive_message()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             var someObject = new DummyImplementingClass();
-            Type assignableCheckType = typeof(DateTime);
+            Action act = () => someObject.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
 
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
-            someObject.Invoking(
-                x => x.Should().BeAssignableTo(assignableCheckType, "because we want to test the failure {0}", "message"))
-                .ShouldThrow<AssertFailedException>()
-                .WithMessage(string.Format(
-                    "Expected object to be assignable to {1} because we want to test the failure message, but {0} is not",
-                    typeof(DummyImplementingClass), assignableCheckType));
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage($"*assignable to {typeof(DateTime)}*failure message*{typeof(DummyImplementingClass)} is not*");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/TypeAssertionSpecs.cs
@@ -395,7 +395,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_an_unrelated_type_it_fails_with_a_a_useful_message()
+        public void When_asserting_an_object_is_assignable_to_an_unrelated_type_it_fails_with_a_useful_message()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -411,6 +411,53 @@ namespace FluentAssertions.Specs
                 .WithMessage(string.Format(
                     "Expected type {0} to be assignable to {1} because we want to test the failure message, but it is not",
                     typeof (DummyImplementingClass), typeof (DateTime)));
+        }
+
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_its_own_type_using_type_instance_it_succeeds()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            typeof(DummyImplementingClass).Should().BeAssignableTo(typeof(DummyImplementingClass));
+        }
+
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_to_its_base_type_using_type_instance_it_succeeds()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            typeof(DummyImplementingClass).Should().BeAssignableTo(typeof(DummyBaseClass));
+        }
+
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_to_an_implemented_interface_type_using_type_instance_it_succeeds()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            typeof(DummyImplementingClass).Should().BeAssignableTo(typeof(IDisposable));
+        }
+
+        [TestMethod]
+        public void When_asserting_an_object_is_assignable_to_an_unrelated_type_using_type_instance_it_fails_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Type someType = typeof(DummyImplementingClass);
+            Type assignableCheckType = typeof(DateTime);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            someType.Invoking(
+                x => x.Should().BeAssignableTo(assignableCheckType, "because we want to test the failure {0}", "message"))
+                .ShouldThrow<AssertFailedException>()
+                .WithMessage(string.Format(
+                    "Expected type {0} to be assignable to {1} because we want to test the failure message, but it is not",
+                    someType, assignableCheckType));
         }
 
         #endregion

--- a/Tests/FluentAssertions.Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/TypeAssertionSpecs.cs
@@ -368,7 +368,7 @@ namespace FluentAssertions.Specs
         #region BeAssignableTo
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_its_own_type_it_succeeds()
+        public void When_its_own_type_it_succeeds()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange / Act / Assert
@@ -377,7 +377,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_its_base_type_it_succeeds()
+        public void When_its_base_type_it_succeeds()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange / Act / Assert
@@ -386,7 +386,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_an_implemented_interface_type_it_succeeds()
+        public void When_implemented_interface_type_it_succeeds()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange / Act / Assert
@@ -395,26 +395,23 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_an_unrelated_type_it_fails_with_a_useful_message()
+        public void When_an_unrelated_type_it_fails_with_a_useful_message()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             Type someType = typeof (DummyImplementingClass);
-
+            Action act = () => someType.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message");
+            
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
-            someType.Invoking(
-                x => x.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message"))
-                .ShouldThrow<AssertFailedException>()
-                .WithMessage(string.Format(
-                    "Expected type {0} to be assignable to {1} because we want to test the failure message, but it is not",
-                    typeof (DummyImplementingClass), typeof (DateTime)));
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage($"*{typeof (DummyImplementingClass)} to be assignable to {typeof (DateTime)}*failure message*");
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_its_own_type_using_type_instance_it_succeeds()
+        public void When_its_own_type_instance_it_succeeds()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange / Act / Assert
@@ -423,7 +420,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_its_base_type_using_type_instance_it_succeeds()
+        public void When_its_base_type_instance_it_succeeds()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange / Act / Assert
@@ -432,7 +429,7 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_an_implemented_interface_type_using_type_instance_it_succeeds()
+        public void When_an_implemented_interface_type_instance_it_succeeds()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange / Act / Assert
@@ -441,23 +438,19 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
-        public void When_asserting_an_object_is_assignable_to_an_unrelated_type_using_type_instance_it_fails_with_a_useful_message()
+        public void When_an_unrelated_type_instance_it_fails_with_a_useful_message()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             Type someType = typeof(DummyImplementingClass);
-            Type assignableCheckType = typeof(DateTime);
+            Action act = () => someType.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
 
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
-            someType.Invoking(
-                x => x.Should().BeAssignableTo(assignableCheckType, "because we want to test the failure {0}", "message"))
-                .ShouldThrow<AssertFailedException>()
-                .WithMessage(string.Format(
-                    "Expected type {0} to be assignable to {1} because we want to test the failure message, but it is not",
-                    someType, assignableCheckType));
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage($"*{typeof(DummyImplementingClass)} to be assignable to {typeof(DateTime)}*failure message*");
         }
 
         #endregion


### PR DESCRIPTION
##### Non-generic ReferenceTypeAssertions & TypeAssertions BeAssignableTo enhancement as discussed in #478 

###### Description:
Asserting _subject object or Type should be assignable to given (non-generic) type parameter_. 

###### Changes:
- `ReferenceTypeAssertions` new overload for BeAssignableTo accepting (non-generic) type parameter
- `TypeAssertions` new overload for BeAssignableTo accepting (non-generic) type parameter
- Testing for overload implementation

###### Wiki:
I can add the samples under [Basic Assertions](https://github.com/dennisdoomen/FluentAssertions/wiki#basic-assertions) and [Type, Method and Property Assertions](https://github.com/dennisdoomen/FluentAssertions/wiki#type-method-and-property-assertions) if necessary.

###### Note:
_ReferenceTypeAssertion.BeAssignableTo_ overload does not return _AndWhichContraint_ since the generic type parameter is not present. Instead of returning and-which contraint with object, it returns _AndContraint_.