### PR TITLE
MSTest V2 support

### DIFF
--- a/FluentAssertions.sln
+++ b/FluentAssertions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E5A0B454-22D4-4694-99FF-D6A8B7DE7DA3}"
 	ProjectSection(SolutionItems) = preProject
@@ -83,34 +83,36 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Json.Net40", "Src\FluentAss
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Json.Net45", "Src\FluentAssertions.Json.Net45\Json.Net45.csproj", "{0D460CE7-4B94-4D2C-9F2A-97426A29C533}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSTestV2.Specs", "Tests\TestFrameworks\MSTestV2.Specs\MSTestV2.Specs.csproj", "{A4E37052-5581-4E70-A9C3-FF8364B2F332}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		Src\Core\Core.projitems*{f33ad06b-9cc4-4e7e-9fb2-ea37890658ff}*SharedItemsImports = 13
+		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{00a8d405-6687-47b4-a81c-76b5331d094d}*SharedItemsImports = 4
+		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{0220d206-62e4-4352-89ec-424e0f04d2d3}*SharedItemsImports = 4
+		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{0c23c12c-899f-4ad1-b737-b967a9910c08}*SharedItemsImports = 13
+		Src\FluentAssertions.Json.Shared\Shared.Json.projitems*{0d460ce7-4b94-4d2c-9f2a-97426a29c533}*SharedItemsImports = 4
+		Src\Shared\Shared.projitems*{0ec1cb90-4d32-4020-bcdb-0ab290a355c2}*SharedItemsImports = 4
+		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{11e362b9-2a11-4452-ad28-1f8ac14ae87b}*SharedItemsImports = 4
+		Src\Shared\Shared.projitems*{135391a1-b669-423f-8d8c-04b60dcfb8b1}*SharedItemsImports = 4
+		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{442c9b50-6f91-4cba-8d4e-b470e5cc3d5f}*SharedItemsImports = 4
+		Src\Shared\Shared.projitems*{46445a29-4242-4fd4-9138-a47b2dbea736}*SharedItemsImports = 13
 		Src\FluentAssertions.Json.Shared\Shared.Json.projitems*{5bfd9d5f-431a-4461-a9f6-8b36eada1dcf}*SharedItemsImports = 4
+		Tests\FluentAssertions.Json.Shared.Specs\Shared.Json.Specs.projitems*{63a1554c-db57-463a-9df4-2748eb403dd9}*SharedItemsImports = 4
+		Src\FluentAssertions.Json.Shared\Shared.Json.projitems*{674338e4-7f78-48b8-857f-f0555cb5a703}*SharedItemsImports = 4
+		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{6d8311f2-7599-4bd0-b66c-05e8cf77aab0}*SharedItemsImports = 4
+		Src\FluentAssertions.Json.Shared\Shared.Json.projitems*{74372c82-492f-4c48-8138-ed91a2b23c40}*SharedItemsImports = 4
+		Src\Shared\Shared.projitems*{81d1792f-3c87-49cf-a502-9f232ff3719c}*SharedItemsImports = 4
+		Tests\FluentAssertions.Json.Shared.Specs\Shared.Json.Specs.projitems*{845ed06b-1f6d-4442-bccc-52483561f447}*SharedItemsImports = 13
+		Src\Core\Core.projitems*{8931c5ef-3bac-473a-a343-57791d0917b1}*SharedItemsImports = 4
+		Src\Shared\Shared.projitems*{a5aad876-e48d-4584-b88c-2bbc52e2d875}*SharedItemsImports = 4
+		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{bfa9c5e5-8838-4eb1-bfe6-2cfafbc95e5c}*SharedItemsImports = 4
+		Src\Shared\Shared.projitems*{ce8a220a-faa6-469d-b9b8-5f1834685861}*SharedItemsImports = 4
+		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{d09fc2d5-a5e5-4344-9e42-bced86d21a57}*SharedItemsImports = 4
 		Src\Core\Core.projitems*{db576b1b-f074-49d6-acdd-b2140f8e140f}*SharedItemsImports = 4
 		Src\Shared\Shared.projitems*{e6f895fa-ae44-4750-87f1-d18a7d974377}*SharedItemsImports = 4
-		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{442c9b50-6f91-4cba-8d4e-b470e5cc3d5f}*SharedItemsImports = 4
-		Tests\FluentAssertions.Json.Shared.Specs\Shared.Json.Specs.projitems*{63a1554c-db57-463a-9df4-2748eb403dd9}*SharedItemsImports = 4
-		Src\Shared\Shared.projitems*{46445a29-4242-4fd4-9138-a47b2dbea736}*SharedItemsImports = 13
-		Src\Shared\Shared.projitems*{135391a1-b669-423f-8d8c-04b60dcfb8b1}*SharedItemsImports = 4
-		Src\Shared\Shared.projitems*{f673cc6b-5747-466f-9ab5-0c7ead5e5f95}*SharedItemsImports = 4
-		Tests\FluentAssertions.Json.Shared.Specs\Shared.Json.Specs.projitems*{845ed06b-1f6d-4442-bccc-52483561f447}*SharedItemsImports = 13
-		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{d09fc2d5-a5e5-4344-9e42-bced86d21a57}*SharedItemsImports = 4
-		Src\FluentAssertions.Json.Shared\Shared.Json.projitems*{74372c82-492f-4c48-8138-ed91a2b23c40}*SharedItemsImports = 4
-		Src\FluentAssertions.Json.Shared\Shared.Json.projitems*{0d460ce7-4b94-4d2c-9f2a-97426a29c533}*SharedItemsImports = 4
-		Src\Core\Core.projitems*{8931c5ef-3bac-473a-a343-57791d0917b1}*SharedItemsImports = 4
-		Src\FluentAssertions.Json.Shared\Shared.Json.projitems*{674338e4-7f78-48b8-857f-f0555cb5a703}*SharedItemsImports = 4
+		Src\Core\Core.projitems*{f33ad06b-9cc4-4e7e-9fb2-ea37890658ff}*SharedItemsImports = 13
 		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{f3e17430-fad7-40ad-bf66-e6f23b70bd92}*SharedItemsImports = 4
-		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{00a8d405-6687-47b4-a81c-76b5331d094d}*SharedItemsImports = 4
-		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{bfa9c5e5-8838-4eb1-bfe6-2cfafbc95e5c}*SharedItemsImports = 4
-		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{6d8311f2-7599-4bd0-b66c-05e8cf77aab0}*SharedItemsImports = 4
-		Src\Shared\Shared.projitems*{81d1792f-3c87-49cf-a502-9f232ff3719c}*SharedItemsImports = 4
-		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{0220d206-62e4-4352-89ec-424e0f04d2d3}*SharedItemsImports = 4
-		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{11e362b9-2a11-4452-ad28-1f8ac14ae87b}*SharedItemsImports = 4
-		Tests\FluentAssertions.Shared.Specs\Shared.Specs.projitems*{0c23c12c-899f-4ad1-b737-b967a9910c08}*SharedItemsImports = 13
-		Src\Shared\Shared.projitems*{0ec1cb90-4d32-4020-bcdb-0ab290a355c2}*SharedItemsImports = 4
-		Src\Shared\Shared.projitems*{a5aad876-e48d-4584-b88c-2bbc52e2d875}*SharedItemsImports = 4
-		Src\Shared\Shared.projitems*{ce8a220a-faa6-469d-b9b8-5f1834685861}*SharedItemsImports = 4
+		Src\Shared\Shared.projitems*{f673cc6b-5747-466f-9ab5-0c7ead5e5f95}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -553,6 +555,26 @@ Global
 		{0D460CE7-4B94-4D2C-9F2A-97426A29C533}.Release|x64.Build.0 = Release|Any CPU
 		{0D460CE7-4B94-4D2C-9F2A-97426A29C533}.Release|x86.ActiveCfg = Release|Any CPU
 		{0D460CE7-4B94-4D2C-9F2A-97426A29C533}.Release|x86.Build.0 = Release|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Debug|ARM.Build.0 = Debug|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Debug|x64.Build.0 = Debug|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Debug|x86.Build.0 = Debug|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Release|ARM.ActiveCfg = Release|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Release|ARM.Build.0 = Release|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Release|x64.ActiveCfg = Release|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Release|x64.Build.0 = Release|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Release|x86.ActiveCfg = Release|Any CPU
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -588,6 +610,7 @@ Global
 		{674338E4-7F78-48B8-857F-F0555CB5A703} = {2D1C52B7-E25D-4BD5-8688-A642A6842AA5}
 		{5BFD9D5F-431A-4461-A9F6-8B36EADA1DCF} = {2D1C52B7-E25D-4BD5-8688-A642A6842AA5}
 		{0D460CE7-4B94-4D2C-9F2A-97426A29C533} = {2D1C52B7-E25D-4BD5-8688-A642A6842AA5}
+		{A4E37052-5581-4E70-A9C3-FF8364B2F332} = {4D8FA213-8724-4C43-B68A-F018148D238C}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = FluentAssertions.Silverlight\Silverlight.csproj

--- a/Src/FluentAssertions.Dotnet/Dotnet.csproj
+++ b/Src/FluentAssertions.Dotnet/Dotnet.csproj
@@ -61,6 +61,9 @@
     <Compile Include="..\FluentAssertions.Net40\Execution\MSTestFramework.cs">
       <Link>Execution\MSTestFramework.cs</Link>
     </Compile>
+    <Compile Include="..\FluentAssertions.Net40\Execution\MSTestFrameworkV2.cs">
+      <Link>Execution\MSTestFrameworkV2.cs</Link>
+    </Compile>
     <Compile Include="..\FluentAssertions.Net40\Execution\XUnitTestFramework.cs">
       <Link>Execution\XUnitTestFramework.cs</Link>
     </Compile>

--- a/Src/FluentAssertions.Dotnet/Execution/TestFrameworkProvider.cs
+++ b/Src/FluentAssertions.Dotnet/Execution/TestFrameworkProvider.cs
@@ -19,6 +19,7 @@ namespace FluentAssertions.Execution
             { "mbunit", new MbUnitTestFramework() },
             { "gallio", new GallioTestFramework() },            
             { "mstest", new MSTestFramework() },
+            { "mstestv2", new MSTestFrameworkV2() },
             { "mstest-rt", new MSTestFrameworkRT() },
 
             { "fallback", new FallbackTestFramework() }

--- a/Src/FluentAssertions.Net40/Execution/MSTestFrameworkV2.cs
+++ b/Src/FluentAssertions.Net40/Execution/MSTestFrameworkV2.cs
@@ -1,0 +1,15 @@
+﻿namespace FluentAssertions.Execution
+{
+    internal class MSTestFrameworkV2 : LateBoundTestFramework
+    {
+        protected override string ExceptionFullName
+        {
+            get { return "Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException"; }
+        }
+
+        protected override string AssemblyName
+        {
+            get { return "Microsoft.VisualStudio.TestPlatform.TestFramework"; }
+        }
+    }
+}

--- a/Src/FluentAssertions.Net40/Execution/TestFrameworkProvider.cs
+++ b/Src/FluentAssertions.Net40/Execution/TestFrameworkProvider.cs
@@ -24,6 +24,7 @@ namespace FluentAssertions.Execution
             { "mstest", new MSTestFramework() },
 #if NET45
             { "xunit2", new XUnit2TestFramework()},
+            { "mstestv2", new MSTestFrameworkV2() },
 #endif
             { "fallback", new FallbackTestFramework() }
         };

--- a/Src/FluentAssertions.Net40/Net40.csproj
+++ b/Src/FluentAssertions.Net40/Net40.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Execution\GallioTestFramework.cs" />
     <Compile Include="Execution\MbUnitTestFramework.cs" />
     <Compile Include="Execution\MSpecFramework.cs" />
+    <Compile Include="Execution\MSTestFrameworkV2.cs" />
     <Compile Include="Execution\MSTestFramework.cs" />
     <Compile Include="Execution\NUnitTestFramework.cs" />
     <Compile Include="Execution\TestFrameworkProvider.cs" />

--- a/Src/FluentAssertions.Net45/Net45.csproj
+++ b/Src/FluentAssertions.Net45/Net45.csproj
@@ -87,6 +87,9 @@
     <Compile Include="..\FluentAssertions.Net40\Execution\MSTestFramework.cs">
       <Link>Execution\MSTestFramework.cs</Link>
     </Compile>
+    <Compile Include="..\FluentAssertions.Net40\Execution\MSTestFrameworkV2.cs">
+      <Link>Execution\MSTestFrameworkV2.cs</Link>
+    </Compile>
     <Compile Include="..\FluentAssertions.Net40\Execution\NUnitTestFramework.cs">
       <Link>Execution\NUnitTestFramework.cs</Link>
     </Compile>

--- a/Tests/TestFrameworks/MSTestV2.Specs/FrameworkSpecs.cs
+++ b/Tests/TestFrameworks/MSTestV2.Specs/FrameworkSpecs.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MSTestV2.Specs
+{
+    [TestClass]
+    public class FrameworkSpecs
+    {
+        [TestMethod]
+        public void When_mstestv2_is_used_it_should_throw_mstest_exceptions_for_assertion_failures()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => 0.Should().Be(1);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            Exception exception = act.ShouldThrow<Exception>().Which;
+            exception.GetType().FullName.Should().ContainEquivalentOf("Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException");
+        }
+    }
+}

--- a/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
+++ b/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\MSTest.TestAdapter.1.1.3-preview\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\..\packages\MSTest.TestAdapter.1.1.3-preview\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A4E37052-5581-4E70-A9C3-FF8364B2F332}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MSTestV2.Specs</RootNamespace>
+    <AssemblyName>MSTestV2.Specs</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\MSTest.TestFramework.1.0.4-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\MSTest.TestFramework.1.0.4-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FrameworkSpecs.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Src\FluentAssertions.Core\Core.pcl.csproj">
+      <Project>{8931c5ef-3bac-473a-a343-57791d0917b1}</Project>
+      <Name>Core.pcl</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Src\FluentAssertions.Net45\Net45.csproj">
+      <Project>{81d1792f-3c87-49cf-a502-9f232ff3719c}</Project>
+      <Name>Net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\MSTest.TestAdapter.1.1.3-preview\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MSTest.TestAdapter.1.1.3-preview\build\net45\MSTest.TestAdapter.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Tests/TestFrameworks/MSTestV2.Specs/Properties/AssemblyInfo.cs
+++ b/Tests/TestFrameworks/MSTestV2.Specs/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MSTestV2.Specs")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MSTestV2.Specs")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a4e37052-5581-4e70-a9c3-ff8364b2f332")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tests/TestFrameworks/MSTestV2.Specs/packages.config
+++ b/Tests/TestFrameworks/MSTestV2.Specs/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.1.3-preview" targetFramework="net45" />
+  <package id="MSTest.TestFramework" version="1.0.4-preview" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Adding in support for MSTest V2 which is the next version of the MSTest framework as detailed [here](https://blogs.msdn.microsoft.com/visualstudioalm/2016/06/17/taking-the-mstest-framework-forward-with-mstest-v2/). It supports .Net 4.5+, UWP and dotnet core.