### PR TITLE
ReSharper Regex Annotations

### DIFF
--- a/Src/Core/Core.projitems
+++ b/Src/Core/Core.projitems
@@ -201,5 +201,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Types\TypeAssertions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Types\TypeSelector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Types\TypeSelectorAssertions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\JetBrainsAnnotations.cs">
+      <Link>JetBrainsAnnotations.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/Src/Core/Primitives/StringAssertions.cs
+++ b/Src/Core/Primitives/StringAssertions.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using FluentAssertions.Execution;
 
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace FluentAssertions.Primitives
 {
@@ -232,7 +233,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs)
+        public AndConstraint<StringAssertions> MatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
         {
           if (regularExpression == null)
           {
@@ -280,7 +281,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs)
+        public AndConstraint<StringAssertions> NotMatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
         {
           if (regularExpression == null)
           {

--- a/Src/Shared/Shared.shproj
+++ b/Src/Shared/Shared.shproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>46445a29-4242-4fd4-9138-a47b2dbea736</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/Tests/FluentAssertions.Shared.Specs/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/StringAssertionSpecs.cs
@@ -653,11 +653,12 @@ namespace FluentAssertions.Specs
           // Arrange
           //-----------------------------------------------------------------------------------------------------------
           string subject = "hello world!";
+          string invalidRegex = ".**"; // Use local variable for this invalid regex to avoid static R# analysis errors
 
           //-----------------------------------------------------------------------------------------------------------
           // Act
           //-----------------------------------------------------------------------------------------------------------
-          Action act = () => subject.Should().MatchRegex(".**");
+          Action act = () => subject.Should().MatchRegex(invalidRegex);
 
           //-----------------------------------------------------------------------------------------------------------
           // Assert
@@ -756,11 +757,12 @@ namespace FluentAssertions.Specs
           // Arrange
           //-----------------------------------------------------------------------------------------------------------
           string subject = "hello world!";
+          string invalidRegex = ".**"; // Use local variable for this invalid regex to avoid static R# analysis errors
 
           //-----------------------------------------------------------------------------------------------------------
           // Act
           //-----------------------------------------------------------------------------------------------------------
-          Action act = () => subject.Should().NotMatchRegex(".**");
+          Action act = () => subject.Should().NotMatchRegex(invalidRegex);
 
           //-----------------------------------------------------------------------------------------------------------
           // Assert


### PR DESCRIPTION
Add Regex annotations for `Should().MatchRegex()` and `Should().NotMatchRegex()` to get syntax highlighting and error analysis of regular expressions.

![2016-11-20 19_05_14-fluentassertionssamples - microsoft visual studio](https://cloud.githubusercontent.com/assets/388796/20465028/4c9811dc-af54-11e6-9f89-f5d1f323dece.png)
