### PR TITLE
Support timespans shorter than 1 millisecond

### DIFF
--- a/Src/Core/Formatting/TimeSpanValueFormatter.cs
+++ b/Src/Core/Formatting/TimeSpanValueFormatter.cs
@@ -76,8 +76,18 @@ namespace FluentAssertions.Formatting
             AddHoursIfNotZero(absoluteTimespan, fragments);
             AddMinutesIfNotZero(absoluteTimespan, fragments);
             AddSecondsIfNotZero(absoluteTimespan, fragments);
+            AddMicrosecondsIfNotZero(absoluteTimespan, fragments);
 
             return fragments;
+        }
+
+        private static void AddMicrosecondsIfNotZero(TimeSpan timeSpan, List<string> fragments)
+        {
+            if (timeSpan.Ticks > 0 && timeSpan.Ticks < TimeSpan.TicksPerMillisecond)
+            {
+                var microSeconds = timeSpan.Ticks / (double)TimeSpan.TicksPerMillisecond * 1000;
+                fragments.Add(microSeconds.ToString("0.0") + "us");
+            }
         }
 
         private static void AddSecondsIfNotZero(TimeSpan timeSpan, List<string> fragments)

--- a/Tests/FluentAssertions.Shared.Specs/TimeSpanFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/TimeSpanFormatterSpecs.cs
@@ -36,7 +36,9 @@ namespace FluentAssertions.Specs
                new { Input = TimeSpan.FromSeconds(90), Output = "1m and 30s" },
                new { Input = TimeSpan.FromMilliseconds(10), Output = "0.010s" },
                new { Input = TimeSpan.MinValue, Output = "min time span" },
-               new { Input = TimeSpan.MaxValue, Output = "max time span" }
+               new { Input = TimeSpan.MaxValue, Output = "max time span" },
+               new { Input = TimeSpan.FromTicks(1), Output = "0.1us" },
+               new { Input = TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond - 1), Output = "999.9us" }
             };
 
             //-----------------------------------------------------------------------------------------------------------
@@ -60,7 +62,9 @@ namespace FluentAssertions.Specs
                new { Input = new TimeSpan(0, 3, 20, 10, 58).Negate(), Output = "-3h, 20m and 10.058s" },
                new { Input = new TimeSpan(2, 0, 0, 12, 0).Negate(), Output = "-2d and 12s" },
                new { Input = TimeSpan.FromSeconds(90).Negate(), Output = "-1m and 30s" },
-               new { Input = TimeSpan.FromMilliseconds(10).Negate(), Output = "-0.010s" }
+               new { Input = TimeSpan.FromMilliseconds(10).Negate(), Output = "-0.010s" },
+               new { Input = TimeSpan.FromTicks(1).Negate(), Output = "-0.1us" },
+               new { Input = TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond - 1).Negate(), Output = "-999.9us" }
             };
 
             //-----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Currently if an assertion dealing with a sub 1 millisecond timespan fails,
the error message describes the timespan as 'default'. Which makes it hard
to figure out what is going on.

This commit extends the timespan formatter to support timespans between
0.1 microseconds and 1 millisecond.