### PR TITLE
Ensures FA doesn't treat standard .NET exception types as value types.

### DIFF
--- a/Src/Core/AssertionOptions.cs
+++ b/Src/Core/AssertionOptions.cs
@@ -1,6 +1,7 @@
 ﻿#region
 
 using System;
+using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 
 #endregion
@@ -32,7 +33,9 @@ namespace FluentAssertions
         /// Returns <c>true</c> if the object should be treated as a value type and its <see cref="object.Equals(object)"/>
         /// must be used during a structural equivalency check.
         /// </returns>
-        public static Func<Type, bool> IsValueType = type => (type.Namespace == typeof (int).Namespace);
+        public static Func<Type, bool> IsValueType = type => 
+            (type.Namespace == typeof (int).Namespace) && 
+            !type.IsSameOrInherits(typeof(Exception));
 
         /// <summary>
         /// Allows configuring the defaults used during a structural equivalency assertion.

--- a/Src/Core/Equivalency/EquivalencyValidator.cs
+++ b/Src/Core/Equivalency/EquivalencyValidator.cs
@@ -50,9 +50,19 @@ namespace FluentAssertions.Equivalency
 
                 if (!objectTracker.IsCyclicReference(new ObjectReference(context.Subject, context.SelectedMemberPath)))
                 {
-                    bool wasHandled = AssertionOptions.EquivalencySteps
-                        .Where(s => s.CanHandle(context, config))
-                        .Any(step => step.Handle(context, this, config));
+                    bool wasHandled = false;
+
+                    foreach (var step in AssertionOptions.EquivalencySteps)
+                    {
+                        if (step.CanHandle(context, config))
+                        {
+                            if (step.Handle(context, this, config))
+                            {
+                                wasHandled = true;
+                                break;
+                            }
+                        }
+                    }
 
                     if (!wasHandled)
                     {

--- a/Tests/FluentAssertions.Shared.Specs/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/ObjectAssertionSpecs.cs
@@ -781,6 +781,25 @@ namespace FluentAssertions.Specs
                     ex.Message.Contains("member Name to be"));
         }
 
+        [TestMethod]
+        public void When_a_system_exception_is_asserted_to_be_serializable_it_should_compare_its_fields_and_properties()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new Exception("some error");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeBinarySerializable();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
         internal class UnserializableClass
         {
             public string Name { get; set; }


### PR DESCRIPTION
Fixes #485