### PR TITLE
[WIP] - Cross Compile Project

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
@@ -1314,7 +1315,7 @@ namespace FluentAssertions.Collections
                 .ForCondition(subject => subject.All(x => x != null))
                 .FailWith("but found a null element.")
                 .Then
-                .ForCondition(subject => subject.All(x => expectedType.IsAssignableFrom(x.GetType())))
+                .ForCondition(subject => subject.All(x => expectedType.GetTypeInfo().IsAssignableFrom(x.GetType().GetTypeInfo())))
                 .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => x.GetType().FullName))}]");
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Common/ProbingAdapterResolver.cs
+++ b/Src/FluentAssertions/Common/ProbingAdapterResolver.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Common
     {
         #region Private Definitions
 
-#if NEW_REFLECTION
+#if !NET45
         private readonly Func<AssemblyName, Assembly> assemblyLoader;
 #else
         private readonly Func<string, Assembly> assemblyLoader;
@@ -33,7 +33,7 @@ namespace FluentAssertions.Common
         {            
         }
 
-#if NEW_REFLECTION
+#if !NET45
         public ProbingAdapterResolver(Func<AssemblyName, Assembly> assemblyLoader)
         {
             this.assemblyLoader = assemblyLoader;
@@ -65,7 +65,7 @@ namespace FluentAssertions.Common
         {
             string typeName = MakeAdapterTypeName(interfaceType);
 
-#if NEW_REFLECTION
+#if !NET45
             Type type = assembly.GetType(typeName, throwOnError: false, ignoreCase: false);
 #else
             Type type = assembly.GetType(typeName, throwOnError: false);
@@ -101,7 +101,7 @@ namespace FluentAssertions.Common
 
         private Assembly ProbeForPlatformSpecificAssembly()
         {
-#if NEW_REFLECTION
+#if !NET45
             var assemblyName = new AssemblyName(GetType().GetTypeInfo().Assembly.FullName) { Name = "FluentAssertions" };
 #else
             var assemblyName = new AssemblyName(GetType().Assembly.FullName) { Name = "FluentAssertions" };
@@ -109,7 +109,7 @@ namespace FluentAssertions.Common
 
             try
             {
-#if NEW_REFLECTION
+#if !NET45
                 return assemblyLoader(assemblyName);
 #else
                 return assemblyLoader(assemblyName.FullName);

--- a/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
@@ -1,7 +1,7 @@
 #region
 
 using System;
-using System.Globalization;
+using System.Reflection;
 
 #endregion
 
@@ -16,8 +16,8 @@ namespace FluentAssertions.Equivalency
         {
             Type subjectType = config.GetSubjectType(context);
 
-            return ((subjectType != null) && subjectType.IsEnum()) ||
-                   ((context.Expectation != null) && context.Expectation.GetType().IsEnum());
+            return ((subjectType != null) && subjectType.GetTypeInfo().IsEnum) ||
+                   ((context.Expectation != null) && context.Expectation.GetType().GetTypeInfo().IsEnum);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Events/EventHandlerFactory.cs
+++ b/Src/FluentAssertions/Events/EventHandlerFactory.cs
@@ -27,6 +27,7 @@ namespace FluentAssertions.Events
                 returnType,
                 AppendParameterListThisReference(parameters),
                 recorder.GetType()
+                .GetTypeInfo()
                 .Module);
 #else
             var eventHandler = new DynamicMethod(
@@ -60,7 +61,7 @@ namespace FluentAssertions.Events
                 ilGen.Emit(OpCodes.Ldarg, index + 1);
                 
                 // Box value-type parameters
-                if (parameters[index]
+                if (parameters[index].GetTypeInfo()
                     .IsValueType)
                 {
                     ilGen.Emit(OpCodes.Box, parameters[index]);
@@ -133,7 +134,7 @@ namespace FluentAssertions.Events
         /// </summary>
         private static bool TypeIsDelegate(Type d)
         {
-            if (d
+            if (d.GetTypeInfo()
                 .BaseType != typeof (MulticastDelegate))
             {
                 return false;

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -49,7 +49,7 @@ namespace FluentAssertions.Execution
 #else
                 string prefix = AssemblyName + ",";
 
-#if !PORTABLE
+#if NET45 // TODO :: AppDomains on netcore
                 assembly = AppDomain.CurrentDomain
                     .GetAssemblies()
                     .FirstOrDefault(a => a.FullName.StartsWith(prefix, StringComparison.CurrentCultureIgnoreCase));

--- a/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
+++ b/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
@@ -1,96 +1,96 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿//using System;
+//using System.Collections.Generic;
+//using System.Linq;
 
-namespace FluentAssertions.Execution
-{
-    internal static class TestFrameworkProvider
-    {
-        #region Private Definitions
+//namespace FluentAssertions.Execution
+//{
+//    internal static class TestFrameworkProvider
+//    {
+//        #region Private Definitions
 
-        private const string AppSettingKey = "FluentAssertions.TestFramework";
+//        private const string AppSettingKey = "FluentAssertions.TestFramework";
 
-        private static readonly Dictionary<string, ITestFramework> frameworks = new Dictionary<string, ITestFramework>
-        {
-            { "nunit", new NUnitTestFramework() },
-            { "xunit", new XUnitTestFramework() },
-            { "mspec", new MSpecFramework() },
-            { "mbunit", new MbUnitTestFramework() },
-            { "gallio", new GallioTestFramework() },
-            { "mstest", new MSTestFramework() },
-#if NET45
-            { "xunit2", new XUnit2TestFramework()},
-            { "mstestv2", new MSTestFrameworkV2() },
-#endif
-            { "fallback", new FallbackTestFramework() }
-        };
+//        private static readonly Dictionary<string, ITestFramework> frameworks = new Dictionary<string, ITestFramework>
+//        {
+//            { "nunit", new NUnitTestFramework() },
+//            { "xunit", new XUnitTestFramework() },
+//            { "mspec", new MSpecFramework() },
+//            { "mbunit", new MbUnitTestFramework() },
+//            { "gallio", new GallioTestFramework() },
+//            { "mstest", new MSTestFramework() },
+//#if NET45
+//            { "xunit2", new XUnit2TestFramework()},
+//            { "mstestv2", new MSTestFrameworkV2() },
+//#endif
+//            { "fallback", new FallbackTestFramework() }
+//        };
 
-        private static ITestFramework testFramework;
+//        private static ITestFramework testFramework;
 
-        #endregion
+//        #endregion
 
-        public static void Throw(string message)
-        {
-            if (testFramework == null)
-            {
-                testFramework = DetectFramework();
-            }
+//        public static void Throw(string message)
+//        {
+//            if (testFramework == null)
+//            {
+//                testFramework = DetectFramework();
+//            }
 
-            testFramework.Throw(message);
-        }
+//            testFramework.Throw(message);
+//        }
 
-        private static ITestFramework DetectFramework()
-        {
-            ITestFramework detectedFramework = null;
+//        private static ITestFramework DetectFramework()
+//        {
+//            ITestFramework detectedFramework = null;
 
-            detectedFramework = AttemptToDetectUsingAppSetting();
-            if (detectedFramework == null)
-            {
-                detectedFramework = AttemptToDetectUsingAssemblyScanning();
-            }
+//            detectedFramework = AttemptToDetectUsingAppSetting();
+//            if (detectedFramework == null)
+//            {
+//                detectedFramework = AttemptToDetectUsingAssemblyScanning();
+//            }
 
-            if (detectedFramework == null)
-            {
-                FailWithIncorrectConfiguration();
-            }
+//            if (detectedFramework == null)
+//            {
+//                FailWithIncorrectConfiguration();
+//            }
 
-            return detectedFramework;
-        }
+//            return detectedFramework;
+//        }
 
-        private static void FailWithIncorrectConfiguration()
-        {
-            string errorMessage =
-                "Failed to detect the test framework. Make sure that the framework assembly is copied into the test run directory"
-                + ", or configure it explicitly in the <appSettings> section using key \"" + AppSettingKey +
-                "\" and one of the supported " +
-                " frameworks: " + string.Join(", ", frameworks.Keys.ToArray());
+//        private static void FailWithIncorrectConfiguration()
+//        {
+//            string errorMessage =
+//                "Failed to detect the test framework. Make sure that the framework assembly is copied into the test run directory"
+//                + ", or configure it explicitly in the <appSettings> section using key \"" + AppSettingKey +
+//                "\" and one of the supported " +
+//                " frameworks: " + string.Join(", ", frameworks.Keys.ToArray());
 
-            throw new ConfigurationErrorsException(errorMessage);
-        }
+//            throw new ConfigurationErrorsException(errorMessage);
+//        }
 
-        private static ITestFramework AttemptToDetectUsingAppSetting()
-        {
-            string frameworkName = ConfigurationManager.AppSettings[AppSettingKey];
+//        private static ITestFramework AttemptToDetectUsingAppSetting()
+//        {
+//            string frameworkName = ConfigurationManager.AppSettings[AppSettingKey];
 
-            if (!string.IsNullOrEmpty(frameworkName) && frameworks.ContainsKey(frameworkName.ToLower()))
-            {
-                ITestFramework framework = frameworks[frameworkName.ToLower()];
-                if (!framework.IsAvailable)
-                {
-                    throw new Exception(
-                        "FluentAssertions was configured to use " + frameworkName +
-                        " but the required test framework assembly could not be found");
-                }
+//            if (!string.IsNullOrEmpty(frameworkName) && frameworks.ContainsKey(frameworkName.ToLower()))
+//            {
+//                ITestFramework framework = frameworks[frameworkName.ToLower()];
+//                if (!framework.IsAvailable)
+//                {
+//                    throw new Exception(
+//                        "FluentAssertions was configured to use " + frameworkName +
+//                        " but the required test framework assembly could not be found");
+//                }
 
-                return framework;
-            }
+//                return framework;
+//            }
 
-            return null;
-        }
+//            return null;
+//        }
 
-        private static ITestFramework AttemptToDetectUsingAssemblyScanning()
-        {
-            return frameworks.Values.FirstOrDefault(framework => framework.IsAvailable);
-        }
-    }
-}
+//        private static ITestFramework AttemptToDetectUsingAssemblyScanning()
+//        {
+//            return frameworks.Values.FirstOrDefault(framework => framework.IsAvailable);
+//        }
+//    }
+//}

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -8,13 +8,17 @@
 
   <ItemGroup>
     <Compile Include="..\JetBrainsAnnotations.cs" Link="JetBrainsAnnotations.cs" />
-    <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
+    <None Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
-    <PackageReference Include="System.Reflection.TypeExtensions">
-      <Version>4.3.0</Version>
-    </PackageReference>
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+  </ItemGroup>
+  
 </Project>

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -11,4 +11,10 @@
     <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
+    <PackageReference Include="System.Reflection.TypeExtensions">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 
 using FluentAssertions.Execution;
-
+using System.Reflection;
 
 namespace FluentAssertions.Numeric
 {
@@ -321,7 +321,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NumericAssertions<T>> BeOfType(Type expectedType, string because = "", params object[] becauseArgs)
         {
             Type subjectType = Subject.GetType();
-            if (expectedType.IsGenericTypeDefinition() && subjectType.IsGenericType())
+            if (expectedType.GetTypeInfo().IsGenericTypeDefinition && subjectType.GetTypeInfo().IsGenericType)
             {
                 subjectType.GetGenericTypeDefinition().Should().Be(expectedType, because, becauseArgs);
             }

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Linq.Expressions;
 
 using FluentAssertions.Execution;
+using System.Reflection;
 
 namespace FluentAssertions.Primitives
 {
@@ -141,7 +142,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:type} to be {0}{reason}, but found <null>.", expectedType);
 
             Type subjectType = Subject.GetType(); 
-            if (expectedType.IsGenericTypeDefinition() && subjectType.IsGenericType())
+            if (expectedType.GetTypeInfo().IsGenericTypeDefinition && subjectType.GetTypeInfo().IsGenericType)
             {
                 subjectType.GetGenericTypeDefinition().Should().Be(expectedType, because, becauseArgs);
             } 

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Reflection
             Subject = assembly;
         }
 
-#if !PORTABLE && !SILVERLIGHT && !WINRT && !CORE_CLR
+#if NET45 // TODO :: Should be able to remove based on: https://github.com/dotnet/corefx/issues/1784#issuecomment-218803619
 
         /// <summary>
         /// Asserts that an assembly does not reference the specified assembly.

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -291,7 +291,7 @@ namespace FluentAssertions.Types
                 throw new ArgumentException("Must not be an interface Type.", "baseType");
             }
 
-            Execute.Assertion.ForCondition(Subject.IsSubclassOf(baseType))
+            Execute.Assertion.ForCondition(Subject.GetTypeInfo().IsSubclassOf(baseType))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to be derived from {1}{reason}, but it is not.", Subject, baseType);
 

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -31,7 +31,7 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatDeriveFrom<TBase>()
         {
-            types = types.Where(type => type.IsSubclassOf(typeof(TBase))).ToList();
+            types = types.Where(type => type.GetTypeInfo().IsSubclassOf(typeof(TBase))).ToList();
             return this;
         }
 
@@ -53,7 +53,7 @@ namespace FluentAssertions.Types
         public TypeSelector ThatAreDecoratedWith<TAttribute>()
         {
             types = types
-#if NEW_REFLECTION
+#if !NET45
                 .Where(t => t.GetTypeInfo().GetCustomAttributes(typeof(TAttribute), true).Any())
 #else
                 .Where(t => t.GetCustomAttributes(typeof(TAttribute), true).Length > 0)


### PR DESCRIPTION
I had to temporarily remove [SolutionInfo.cs](https://github.com/dennisdoomen/fluentassertions/pull/2/files#diff-e679360363918435f2e802e5af672ab4R11) from the compilation as it caused a duplicate assembly attribute. Can probably put all the attributes in the csproj ([Example](https://github.com/Im5tu/OpenMessage/blob/dev/src/OpenMessage/OpenMessage.csproj#L4))

TODO
- [ ] Review all `#if` statements
- [ ] Review AppDomains on NetCore [here](https://github.com/dennisdoomen/fluentassertions/pull/2/files#diff-a61b9cbf5f19af269a77d1eb94c0b886R66) and [here](https://github.com/dennisdoomen/fluentassertions/pull/2/files#diff-4321be4d4031e569258c0e048e6a7b23R52)
- [ ] Review usage of [TestFrameworkProvider](https://github.com/dennisdoomen/fluentassertions/pull/2/files#diff-8d57b01cf6fdad55cafecc2226e55e3d) (I think this is unused, or VS could be lying to me. Can you confirm?)
- [ ] Review usage of [Assembly.GetReferencedAssemblies](https://github.com/dennisdoomen/fluentassertions/pull/2/files#diff-8a8b485843915c5b2e79089b695e8427R22)
- [ ] Fix test projects