### PR TITLE
fix: prevent pwn-request RCE via Qodana workflow

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,0 +1,24 @@
+name: Qodana
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  qodana-scan:
+    name: Qodana Scan
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: 'Qodana Scan'
+        uses: JetBrains/qodana-action@v2026.1
+        with:
+          upload-result: true
+          args: --baseline qodana.sarif.json --linter qodana-dotnet --within-docker false
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/.github/workflows/code_quality_pr.yml
+++ b/.github/workflows/code_quality_pr.yml
@@ -1,0 +1,38 @@
+name: Qodana (PR)
+
+# Triggered by pull_request (NOT pull_request_target) so this job runs with
+# the PR contributor's code but WITHOUT access to repository secrets. That is
+# the safe half of the two-workflow "pwn-request" mitigation pattern.
+on:
+  pull_request:
+
+jobs:
+  qodana-scan:
+    name: Qodana Scan
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: 'Qodana Scan'
+        uses: JetBrains/qodana-action@v2026.1
+        with:
+          # Do not upload here — no token is available in pull_request context.
+          upload-result: false
+          args: --baseline qodana.sarif.json --linter qodana-dotnet --within-docker false
+          pr-mode: true
+          results-dir: ${{ runner.temp }}/qodana-results
+
+      # Persist the PR number alongside the results so the upload workflow can
+      # associate the report with the correct pull request.
+      - name: Save PR number
+        shell: bash
+        run: echo "${{ github.event.pull_request.number }}" > "${{ runner.temp }}/qodana-results/pr-number.txt"
+
+      - name: Upload Qodana results artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qodana-results
+          path: ${{ runner.temp }}/qodana-results

--- a/.github/workflows/code_quality_upload.yml
+++ b/.github/workflows/code_quality_upload.yml
@@ -1,0 +1,36 @@
+name: Qodana (Upload)
+
+# Triggered only after the "Qodana (PR)" workflow completes successfully.
+# workflow_run always executes on the default branch of the base repository,
+# so QODANA_TOKEN is available here — but crucially NO PR contributor code is
+# ever checked out or executed in this job. This is the safe half of the
+# two-workflow "pwn-request" mitigation pattern.
+on:
+  workflow_run:
+    workflows: ["Qodana (PR)"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    name: Upload to Qodana Cloud
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download Qodana results artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qodana-results
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: qodana-results
+
+      - name: Install Qodana CLI
+        run: |
+          curl -fsSL https://jb.gg/qodana-cli/install | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Upload results to Qodana Cloud
+        run: qodana send --report-dir qodana-results
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}


### PR DESCRIPTION
## Security vulnerability fixed

### The problem

`.github/workflows/code_quality.yml` used `pull_request_target` (which runs on the **base repo** with access to repository secrets) together with:

```yaml
- uses: actions/checkout@v6
  with:
    ref: ${{ github.event.pull_request.head.sha }}
```

This checks out **untrusted contributor code** in a privileged context. Because `QODANA_TOKEN` is injected via `env:`, any PR from an external contributor could exfiltrate or abuse it — a classic ["pwn request"](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) RCE pattern.

### The fix: two-workflow pattern

The single vulnerable workflow is replaced with three:

| File | Trigger | Secrets? | Runs contributor code? |
|---|---|---|---|
| `code_quality.yml` | `push` to `main`/`develop`, `workflow_dispatch` | ✅ Yes | ❌ No (trusted) |
| `code_quality_pr.yml` | `pull_request` | ❌ No | ✅ Yes (safe — no secrets) |
| `code_quality_upload.yml` | `workflow_run` (after PR analysis) | ✅ Yes | ❌ No |

**Workflow 1 (`code_quality.yml`)** — unchanged behaviour for branch pushes and manual triggers. Checks out trusted code and uploads results to Qodana Cloud with `QODANA_TOKEN`.

**Workflow 2 (`code_quality_pr.yml`)** — triggered by `pull_request` (not `pull_request_target`). Runs with contributor code but **has no access to secrets**. Runs Qodana with `upload-result: false`, then saves the results directory and the PR number as a GitHub Actions artifact.

**Workflow 3 (`code_quality_upload.yml`)** — triggered by `workflow_run` on completion of Workflow 2. Always runs on the **default branch**, so `QODANA_TOKEN` is available. **Never checks out any PR code.** Downloads the artifact and uploads results to Qodana Cloud via `qodana send`.

### References

- [GitHub Security Lab: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
- [Qodana GitHub Actions integration](https://www.jetbrains.com/help/qodana/github.html)